### PR TITLE
DSND-630 - Improve logging with contextId

### DIFF
--- a/src/main/java/uk/gov/companieshouse/company/links/processor/StreamResponseProcessor.java
+++ b/src/main/java/uk/gov/companieshouse/company/links/processor/StreamResponseProcessor.java
@@ -1,5 +1,6 @@
 package uk.gov.companieshouse.company.links.processor;
 
+import java.util.List;
 import java.util.Map;
 import org.springframework.http.HttpStatus;
 import uk.gov.companieshouse.company.links.exception.NonRetryableErrorException;
@@ -21,11 +22,13 @@ public class StreamResponseProcessor {
     void handleResponse(
             final HttpStatus httpStatus,
             final String logContext,
-            String message,
+            String requestTypeAndService,
+            String companyNumber,
             final Map<String, Object> logMap)
             throws NonRetryableErrorException, RetryableErrorException {
-
+        String message = "Response from " + requestTypeAndService;
         logMap.put("status", httpStatus.toString());
+        logMap.put("company_number", companyNumber);
 
         if (HttpStatus.BAD_REQUEST == httpStatus) {
             // 400 BAD REQUEST status is not retryable
@@ -36,7 +39,9 @@ public class StreamResponseProcessor {
             logger.errorContext(logContext, message, null, logMap);
             throw new RetryableErrorException(message);
         } else {
-            logger.trace("Got successful response");
+            logger.info(String.format("Successfully invoked %s endpoint"
+                            + " for message with contextId %s and company number %s",
+                    requestTypeAndService, logContext, companyNumber));
         }
     }
 }

--- a/src/main/java/uk/gov/companieshouse/company/links/serialization/ResourceChangedDataDeserializer.java
+++ b/src/main/java/uk/gov/companieshouse/company/links/serialization/ResourceChangedDataDeserializer.java
@@ -12,7 +12,6 @@ import uk.gov.companieshouse.company.links.exception.NonRetryableErrorException;
 import uk.gov.companieshouse.logging.Logger;
 import uk.gov.companieshouse.stream.ResourceChangedData;
 
-//Confirmed that charges and insolvency will have same avro schema
 @Component
 public class ResourceChangedDataDeserializer implements Deserializer<ResourceChangedData> {
 

--- a/src/main/java/uk/gov/companieshouse/company/links/service/CompanyProfileService.java
+++ b/src/main/java/uk/gov/companieshouse/company/links/service/CompanyProfileService.java
@@ -1,14 +1,10 @@
 package uk.gov.companieshouse.company.links.service;
 
-import java.util.HashMap;
-import java.util.Map;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import uk.gov.companieshouse.api.InternalApiClient;
 import uk.gov.companieshouse.api.company.CompanyProfile;
-import uk.gov.companieshouse.api.handler.company.PrivateCompanyResourceHandler;
-import uk.gov.companieshouse.api.handler.company.request.PrivateCompanyProfileGet;
 import uk.gov.companieshouse.api.http.ApiKeyHttpClient;
 import uk.gov.companieshouse.api.http.HttpClient;
 import uk.gov.companieshouse.api.model.ApiResponse;
@@ -41,10 +37,10 @@ public class CompanyProfileService extends BaseApiClientService {
      */
     public ApiResponse<CompanyProfile> getCompanyProfile(String contextId, String companyNumber)
             throws RetryableErrorException {
-        String uri = String.format("/company/%s/links", companyNumber);
+        logger.trace(String.format("Call to GET company profile with contextId %s "
+                        + "and company number %s", contextId, companyNumber));
 
-        Map<String, Object> logMap = createLogMap(companyNumber, "GET", uri);
-        logger.infoContext(contextId, String.format("GET %s", uri), logMap);
+        String uri = String.format("/company/%s/links", companyNumber);
         return executeOp(contextId, "getCompanyProfileApi", uri,
             getApiClient(contextId)
                 .privateCompanyResourceHandler()
@@ -75,22 +71,13 @@ public class CompanyProfileService extends BaseApiClientService {
      */
     public ApiResponse<Void> patchCompanyProfile(String contextId, String companyNumber,
                                                  CompanyProfile companyProfile) {
+        logger.trace(String.format("Call to PATCH company profile with contextId %s "
+                + "and company number %s", contextId, companyNumber));
+
         String uri = String.format("/company/%s/links", companyNumber);
-
-        Map<String, Object> logMap = createLogMap(companyNumber, "PATCH", uri);
-        logger.infoContext(contextId, String.format("PATCH %s", uri), logMap);
-
         return executeOp(contextId, "patchCompanyProfileApi", uri,
                 getApiClient(contextId)
                         .privateCompanyResourceHandler()
                         .patchCompanyProfile(uri, companyProfile));
-    }
-
-    private Map<String, Object> createLogMap(String companyNumber, String method, String path) {
-        final Map<String, Object> logMap = new HashMap<>();
-        logMap.put("company_number", companyNumber);
-        logMap.put("method", method);
-        logMap.put("path", path);
-        return logMap;
     }
 }


### PR DESCRIPTION
- Adds INFO level logs on consumer entry point (message consumed) and on `GET` and `PATCH` requests to `company-profile-api` - INFO level logs kept to a minimum and only highlight important events of relevance to the support team - successful invocation of Kafka-api or a endpoint invoked successfully.
- Tidies up existing TRACE level dev-oriented logs 
- Refactored both charges and insolvency stream processors - improved logic flow and unified logging across both.
- Tidies up existing tests addressing Sonar issues, extends coverage to log statements
