### PR TITLE
DSND 1580: Additional requirements remove officers link

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,7 @@
 		<ch-kafka.version>1.4.2</ch-kafka.version>
 		<structured-logging.version>1.9.12</structured-logging.version>
 		<kafka-models.version>1.0.27</kafka-models.version>
-		<private-api-sdk-java.version>unversioned</private-api-sdk-java.version>
+		<private-api-sdk-java.version>2.0.230</private-api-sdk-java.version>
 		<api-sdk-manager-java-library.version>1.0.4</api-sdk-manager-java-library.version>
 		<jib-maven-plugin.version>3.1.1</jib-maven-plugin.version>
 		<springfox-boot-starter.version>3.0.0</springfox-boot-starter.version>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>uk.gov.companieshouse</groupId>
 		<artifactId>companies-house-parent</artifactId>
-		<version>1.3.0</version>
+		<version>1.3.1</version>
 	</parent>
 
 	<artifactId>company-links-consumer</artifactId>
@@ -23,7 +23,7 @@
 		<maven.compiler.source>${java.version}</maven.compiler.source>
 		<maven.compiler.target>${java.version}</maven.compiler.target>
 		<maven-compiler-plugin.version>3.8.1</maven-compiler-plugin.version>
-		<spring.boot.version>2.6.4</spring.boot.version>
+		<spring.boot.version>2.7.9</spring.boot.version>
 		<assertj-core.version>3.22.0</assertj-core.version>
 		<test-containers.version>1.16.2</test-containers.version>
 		<map-struct.version>1.4.2.Final</map-struct.version>
@@ -34,7 +34,7 @@
 		<ch-kafka.version>1.4.2</ch-kafka.version>
 		<structured-logging.version>1.9.12</structured-logging.version>
 		<kafka-models.version>1.0.27</kafka-models.version>
-		<private-api-sdk-java.version>2.0.216</private-api-sdk-java.version>
+		<private-api-sdk-java.version>unversioned</private-api-sdk-java.version>
 		<api-sdk-manager-java-library.version>1.0.4</api-sdk-manager-java-library.version>
 		<jib-maven-plugin.version>3.1.1</jib-maven-plugin.version>
 		<springfox-boot-starter.version>3.0.0</springfox-boot-starter.version>

--- a/src/itest/resources/features/company-links-officers.feature
+++ b/src/itest/resources/features/company-links-officers.feature
@@ -31,13 +31,22 @@ Feature: Process company links information for officers
 
   Scenario: PATCH company officers link successfully - remove link
     Given Company links consumer is available
+    And The number of officers remaining in the company is 0
     When  A valid "deleted" message is consumed from the "officers" stream
     Then  A PATCH request is sent to the API
+    And No messages are placed on the invalid, error or retry topics
+
+  Scenario: PATCH company officers link fails to delete officers - remove link
+    Given Company links consumer is available
+    And The number of officers remaining in the company is 2
+    When  A valid "deleted" message is consumed from the "officers" stream
+    Then  A PATCH request is NOT sent to the API
     And No messages are placed on the invalid, error or retry topics
 
   Scenario: Consume a valid officers message but the user is not authorized - remove link
     Given Company links consumer is available
     And   The user is unauthorized
+    And The number of officers remaining in the company is 0
     When A valid "deleted" message is consumed from the "officers" stream
     Then The message is placed on the "invalid" topic
 
@@ -47,3 +56,10 @@ Feature: Process company links information for officers
     When A valid "deleted" message is consumed from the "officers" stream
     Then The message is placed on the "retry" topic
     And  The message is placed on the "error" topic
+
+  Scenario: Consume a valid officers message but the company appointments api is unavailable - remove link
+    Given Company links consumer is available
+    And   The company appointments api is unavailable
+    When A valid "deleted" message is consumed from the "officers" stream
+    Then The message is placed on the "retry" topic
+    

--- a/src/main/java/uk/gov/companieshouse/company/links/config/LinkClientConfig.java
+++ b/src/main/java/uk/gov/companieshouse/company/links/config/LinkClientConfig.java
@@ -1,8 +1,6 @@
 package uk.gov.companieshouse.company.links.config;
 
-import java.util.HashMap;
 import java.util.Map;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import uk.gov.companieshouse.company.links.service.LinkClient;
@@ -10,29 +8,25 @@ import uk.gov.companieshouse.company.links.service.LinkClient;
 @Configuration
 public class LinkClientConfig {
 
-    @Autowired
-    private LinkClient addExemptionsClient;
-    @Autowired
-    private LinkClient deleteExemptionsClient;
-    @Autowired
-    private LinkClient addOfficersClient;
-    @Autowired
-    private LinkClient removeOfficersClient;
+    private static final String EXEMPTIONS = "exemptions";
+    private static final String CHANGED = "changed";
+    private static final String DELETED = "deleted";
+    private static final String OFFICERS = "officers";
 
     @Bean
-    Map<String, Map<String, LinkClient>> linkClientMap() {
-        Map<String, Map<String, LinkClient>> linkClientConfig = new HashMap<>();
+    Map<String, Map<String, LinkClient>> linkClientMap(
+            LinkClient addExemptionsClient,
+            LinkClient deleteExemptionsClient,
+            LinkClient addOfficersClient,
+            LinkClient removeOfficersClient) {
 
-        Map<String, LinkClient> exemptionsClientConfig = new HashMap<>();
-        exemptionsClientConfig.put("changed", addExemptionsClient);
-        exemptionsClientConfig.put("deleted", deleteExemptionsClient);
-        linkClientConfig.put("exemptions", exemptionsClientConfig);
+        return Map.of(
+                EXEMPTIONS, Map.of(
+                        CHANGED, addExemptionsClient,
+                        DELETED, deleteExemptionsClient),
+                OFFICERS, Map.of(
+                        CHANGED, addOfficersClient,
+                        DELETED, removeOfficersClient));
 
-        Map<String, LinkClient> officersClientConfig = new HashMap<>();
-        officersClientConfig.put("changed", addOfficersClient);
-        officersClientConfig.put("deleted", removeOfficersClient);
-        linkClientConfig.put("officers", officersClientConfig);
-
-        return linkClientConfig;
     }
 }

--- a/src/main/java/uk/gov/companieshouse/company/links/processor/LinkRouter.java
+++ b/src/main/java/uk/gov/companieshouse/company/links/processor/LinkRouter.java
@@ -1,17 +1,18 @@
 package uk.gov.companieshouse.company.links.processor;
 
 import org.springframework.stereotype.Component;
-import uk.gov.companieshouse.company.links.service.CompanyNumberExtractable;
+import uk.gov.companieshouse.company.links.service.PatchLinkRequestExtractable;
 import uk.gov.companieshouse.company.links.service.LinkClientFactory;
+import uk.gov.companieshouse.company.links.type.PatchLinkRequest;
 import uk.gov.companieshouse.company.links.type.ResourceChange;
 
 @Component
 public class LinkRouter implements LinkRoutable {
 
-    private final CompanyNumberExtractable extractor;
+    private final PatchLinkRequestExtractable extractor;
     private final LinkClientFactory factory;
 
-    public LinkRouter(CompanyNumberExtractable extractor, LinkClientFactory factory) {
+    public LinkRouter(PatchLinkRequestExtractable extractor, LinkClientFactory factory) {
         this.extractor = extractor;
         this.factory = factory;
     }
@@ -19,7 +20,8 @@ public class LinkRouter implements LinkRoutable {
     @Override
     public void route(ResourceChange message, String deltaType) {
         String eventType = message.getData().getEvent().getType();
-        String companyNumber = extractor.extractCompanyNumber(message.getData().getResourceUri());
-        factory.getLinkClient(deltaType, eventType).patchLink(companyNumber);
+        PatchLinkRequest request = extractor.extractPatchLinkRequest(
+                message.getData().getResourceUri());
+        factory.getLinkClient(deltaType, eventType).patchLink(request);
     }
 }

--- a/src/main/java/uk/gov/companieshouse/company/links/processor/LinkRouter.java
+++ b/src/main/java/uk/gov/companieshouse/company/links/processor/LinkRouter.java
@@ -1,8 +1,8 @@
 package uk.gov.companieshouse.company.links.processor;
 
 import org.springframework.stereotype.Component;
-import uk.gov.companieshouse.company.links.service.PatchLinkRequestExtractable;
 import uk.gov.companieshouse.company.links.service.LinkClientFactory;
+import uk.gov.companieshouse.company.links.service.PatchLinkRequestExtractable;
 import uk.gov.companieshouse.company.links.type.PatchLinkRequest;
 import uk.gov.companieshouse.company.links.type.ResourceChange;
 

--- a/src/main/java/uk/gov/companieshouse/company/links/service/AddExemptionsClient.java
+++ b/src/main/java/uk/gov/companieshouse/company/links/service/AddExemptionsClient.java
@@ -25,7 +25,7 @@ public class AddExemptionsClient implements LinkClient {
      * Sends a patch request to the add exemptions link endpoint in the company profile api and
      * handles any error responses.
      *
-     * @param linkRequest
+     * @param linkRequest PatchLinkRequest
      */
     @Override
     public void patchLink(PatchLinkRequest linkRequest) {
@@ -33,7 +33,8 @@ public class AddExemptionsClient implements LinkClient {
         try {
             client.privateCompanyLinksResourceHandler()
                     .addExemptionsCompanyLink(
-                            String.format("/company/%s/links/exemptions", linkRequest.getCompanyNumber()))
+                            String.format("/company/%s/links/exemptions",
+                                    linkRequest.getCompanyNumber()))
                     .execute();
         } catch (ApiErrorResponseException ex) {
             if (ex.getStatusCode() / 100 == 5) {

--- a/src/main/java/uk/gov/companieshouse/company/links/service/AddExemptionsClient.java
+++ b/src/main/java/uk/gov/companieshouse/company/links/service/AddExemptionsClient.java
@@ -7,6 +7,7 @@ import uk.gov.companieshouse.api.error.ApiErrorResponseException;
 import uk.gov.companieshouse.api.handler.exception.URIValidationException;
 import uk.gov.companieshouse.company.links.exception.NonRetryableErrorException;
 import uk.gov.companieshouse.company.links.exception.RetryableErrorException;
+import uk.gov.companieshouse.company.links.type.PatchLinkRequest;
 import uk.gov.companieshouse.logging.Logger;
 
 @Component
@@ -21,18 +22,18 @@ public class AddExemptionsClient implements LinkClient {
     }
 
     /**
-     * Sends a patch request to the add exemptions link endpoint in the
-     * company profile api and handles any error responses.
+     * Sends a patch request to the add exemptions link endpoint in the company profile api and
+     * handles any error responses.
      *
-     * @param companyNumber The companyNumber of the patch request
+     * @param linkRequest
      */
     @Override
-    public void patchLink(String companyNumber) {
+    public void patchLink(PatchLinkRequest linkRequest) {
         InternalApiClient client = internalApiClientFactory.get();
         try {
             client.privateCompanyLinksResourceHandler()
                     .addExemptionsCompanyLink(
-                            String.format("/company/%s/links/exemptions", companyNumber))
+                            String.format("/company/%s/links/exemptions", linkRequest.getCompanyNumber()))
                     .execute();
         } catch (ApiErrorResponseException ex) {
             if (ex.getStatusCode() / 100 == 5) {

--- a/src/main/java/uk/gov/companieshouse/company/links/service/AddOfficersClient.java
+++ b/src/main/java/uk/gov/companieshouse/company/links/service/AddOfficersClient.java
@@ -25,7 +25,7 @@ public class AddOfficersClient implements LinkClient {
      * Sends a patch request to the add officers link endpoint in the company profile api and
      * handles any error responses.
      *
-     * @param linkRequest
+     * @param linkRequest PatchLinkRequest
      */
     @Override
     public void patchLink(PatchLinkRequest linkRequest) {
@@ -33,7 +33,8 @@ public class AddOfficersClient implements LinkClient {
         try {
             client.privateCompanyLinksResourceHandler()
                     .addOfficersCompanyLink(
-                            String.format("/company/%s/links/officers", linkRequest.getCompanyNumber()))
+                            String.format("/company/%s/links/officers",
+                                    linkRequest.getCompanyNumber()))
                     .execute();
         } catch (ApiErrorResponseException ex) {
             if (ex.getStatusCode() / 100 == 5) {

--- a/src/main/java/uk/gov/companieshouse/company/links/service/AddOfficersClient.java
+++ b/src/main/java/uk/gov/companieshouse/company/links/service/AddOfficersClient.java
@@ -8,6 +8,7 @@ import uk.gov.companieshouse.api.error.ApiErrorResponseException;
 import uk.gov.companieshouse.api.handler.exception.URIValidationException;
 import uk.gov.companieshouse.company.links.exception.NonRetryableErrorException;
 import uk.gov.companieshouse.company.links.exception.RetryableErrorException;
+import uk.gov.companieshouse.company.links.type.PatchLinkRequest;
 import uk.gov.companieshouse.logging.Logger;
 
 @Component
@@ -21,18 +22,18 @@ public class AddOfficersClient implements LinkClient {
     }
 
     /**
-     * Sends a patch request to the add officers link endpoint in the
-     * company profile api and handles any error responses.
+     * Sends a patch request to the add officers link endpoint in the company profile api and
+     * handles any error responses.
      *
-     * @param companyNumber The companyNumber of the patch request
+     * @param linkRequest
      */
     @Override
-    public void patchLink(String companyNumber) {
+    public void patchLink(PatchLinkRequest linkRequest) {
         InternalApiClient client = internalApiClientFactory.get();
         try {
             client.privateCompanyLinksResourceHandler()
                     .addOfficersCompanyLink(
-                            String.format("/company/%s/links/officers", companyNumber))
+                            String.format("/company/%s/links/officers", linkRequest.getCompanyNumber()))
                     .execute();
         } catch (ApiErrorResponseException ex) {
             if (ex.getStatusCode() / 100 == 5) {

--- a/src/main/java/uk/gov/companieshouse/company/links/service/AppointmentsListClient.java
+++ b/src/main/java/uk/gov/companieshouse/company/links/service/AppointmentsListClient.java
@@ -1,0 +1,69 @@
+package uk.gov.companieshouse.company.links.service;
+
+import java.util.function.Supplier;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Component;
+import uk.gov.companieshouse.api.InternalApiClient;
+import uk.gov.companieshouse.api.appointment.OfficerList;
+import uk.gov.companieshouse.api.error.ApiErrorResponseException;
+import uk.gov.companieshouse.api.handler.exception.URIValidationException;
+import uk.gov.companieshouse.company.links.exception.NonRetryableErrorException;
+import uk.gov.companieshouse.company.links.exception.RetryableErrorException;
+import uk.gov.companieshouse.logging.Logger;
+
+@Component
+public class AppointmentsListClient {
+
+    private final Logger logger;
+    private final Supplier<InternalApiClient> internalApiClientFactory;
+
+    public AppointmentsListClient(Logger logger,
+            Supplier<InternalApiClient> internalApiClientFactory) {
+        this.logger = logger;
+        this.internalApiClientFactory = internalApiClientFactory;
+    }
+
+    /**
+     * Retrieves a list of officers appointed to a company.
+     *
+     * @param companyNumber The companyNumber
+     * @return OfficerList
+     */
+    public OfficerList getAppointmentsList(String companyNumber) {
+        InternalApiClient client = internalApiClientFactory.get();
+        try {
+            return client.privateCompanyAppointmentsListHandler()
+                    .getCompanyAppointmentsList(
+                            String.format("/company/%s/officers-test", companyNumber))
+                    .execute()
+                    .getData();
+        } catch (ApiErrorResponseException ex) {
+
+            if (HttpStatus.valueOf(ex.getStatusCode()).is5xxServerError()) {
+                String message = String.format("Server error status code: [%s] "
+                                + "while fetching appointments list for company %s", ex.getStatusCode(),
+                        companyNumber);
+                logger.error(message);
+                throw new RetryableErrorException(message, ex);
+            } else if (ex.getStatusCode() == 404) {
+                logger.debug(String.format("HTTP 404 Not Found returned for company number %s",
+                        companyNumber));
+                return new OfficerList()
+                        .totalResults(0);
+            } else {
+                String message = String.format("Client error status code: [%s] "
+                        + "while fetching appointments list", ex.getStatusCode());
+                logger.error(message);
+                throw new NonRetryableErrorException(message, ex);
+            }
+        } catch (IllegalArgumentException ex) {
+            logger.error("Illegal argument exception caught when handling API response");
+            throw new RetryableErrorException("Error returned when fetching appointments", ex);
+        } catch (URIValidationException ex) {
+            String message = String.format("Invalid companyNumber [%s] when handling API request",
+                    companyNumber);
+            logger.error(message);
+            throw new NonRetryableErrorException(message, ex);
+        }
+    }
+}

--- a/src/main/java/uk/gov/companieshouse/company/links/service/AppointmentsListClient.java
+++ b/src/main/java/uk/gov/companieshouse/company/links/service/AppointmentsListClient.java
@@ -41,7 +41,8 @@ public class AppointmentsListClient {
 
             if (HttpStatus.valueOf(ex.getStatusCode()).is5xxServerError()) {
                 String message = String.format("Server error status code: [%s] "
-                                + "while fetching appointments list for company %s", ex.getStatusCode(),
+                                + "while fetching appointments list for company %s",
+                        ex.getStatusCode(),
                         companyNumber);
                 logger.error(message);
                 throw new RetryableErrorException(message, ex);

--- a/src/main/java/uk/gov/companieshouse/company/links/service/CompanyNumberExtractable.java
+++ b/src/main/java/uk/gov/companieshouse/company/links/service/CompanyNumberExtractable.java
@@ -1,5 +1,0 @@
-package uk.gov.companieshouse.company.links.service;
-
-public interface CompanyNumberExtractable {
-    String extractCompanyNumber(String uri);
-}

--- a/src/main/java/uk/gov/companieshouse/company/links/service/DeleteExemptionsClient.java
+++ b/src/main/java/uk/gov/companieshouse/company/links/service/DeleteExemptionsClient.java
@@ -8,6 +8,7 @@ import uk.gov.companieshouse.api.error.ApiErrorResponseException;
 import uk.gov.companieshouse.api.handler.exception.URIValidationException;
 import uk.gov.companieshouse.company.links.exception.NonRetryableErrorException;
 import uk.gov.companieshouse.company.links.exception.RetryableErrorException;
+import uk.gov.companieshouse.company.links.type.PatchLinkRequest;
 import uk.gov.companieshouse.logging.Logger;
 
 @Component
@@ -22,18 +23,18 @@ public class DeleteExemptionsClient implements LinkClient {
     }
 
     /**
-     * Sends a patch request to the delete exemptions link endpoint in the
-     * company profile api and handles any error responses.
+     * Sends a patch request to the delete exemptions link endpoint in the company profile api and
+     * handles any error responses.
      *
-     * @param companyNumber The companyNumber of the patch request
+     * @param linkRequest
      */
     @Override
-    public void patchLink(String companyNumber) {
+    public void patchLink(PatchLinkRequest linkRequest) {
         InternalApiClient client = internalApiClientFactory.get();
         try {
             client.privateCompanyLinksResourceHandler()
                     .deleteExemptionsCompanyLink(
-                            String.format("/company/%s/links/exemptions/delete", companyNumber))
+                            String.format("/company/%s/links/exemptions/delete", linkRequest.getCompanyNumber()))
                     .execute();
         } catch (ApiErrorResponseException ex) {
             if (ex.getStatusCode() / 100 == 5) {

--- a/src/main/java/uk/gov/companieshouse/company/links/service/DeleteExemptionsClient.java
+++ b/src/main/java/uk/gov/companieshouse/company/links/service/DeleteExemptionsClient.java
@@ -1,7 +1,6 @@
 package uk.gov.companieshouse.company.links.service;
 
 import java.util.function.Supplier;
-
 import org.springframework.stereotype.Component;
 import uk.gov.companieshouse.api.InternalApiClient;
 import uk.gov.companieshouse.api.error.ApiErrorResponseException;
@@ -26,7 +25,7 @@ public class DeleteExemptionsClient implements LinkClient {
      * Sends a patch request to the delete exemptions link endpoint in the company profile api and
      * handles any error responses.
      *
-     * @param linkRequest
+     * @param linkRequest PatchLinkRequest
      */
     @Override
     public void patchLink(PatchLinkRequest linkRequest) {
@@ -34,7 +33,8 @@ public class DeleteExemptionsClient implements LinkClient {
         try {
             client.privateCompanyLinksResourceHandler()
                     .deleteExemptionsCompanyLink(
-                            String.format("/company/%s/links/exemptions/delete", linkRequest.getCompanyNumber()))
+                            String.format("/company/%s/links/exemptions/delete",
+                                    linkRequest.getCompanyNumber()))
                     .execute();
         } catch (ApiErrorResponseException ex) {
             if (ex.getStatusCode() / 100 == 5) {
@@ -50,7 +50,7 @@ public class DeleteExemptionsClient implements LinkClient {
                         + "company profile does not exist");
             } else {
                 logger.error(String.format("Delete exemptions client error returned with status"
-                        + " code: [%s] when processing delete exemptions link request",
+                                + " code: [%s] when processing delete exemptions link request",
                         ex.getStatusCode()));
                 throw new NonRetryableErrorException("DeleteClient error returned when "
                         + "processing delete exemptions link request", ex);

--- a/src/main/java/uk/gov/companieshouse/company/links/service/NullLinkClient.java
+++ b/src/main/java/uk/gov/companieshouse/company/links/service/NullLinkClient.java
@@ -2,6 +2,7 @@ package uk.gov.companieshouse.company.links.service;
 
 import org.springframework.stereotype.Component;
 import uk.gov.companieshouse.company.links.exception.NonRetryableErrorException;
+import uk.gov.companieshouse.company.links.type.PatchLinkRequest;
 import uk.gov.companieshouse.logging.Logger;
 
 @Component
@@ -14,9 +15,10 @@ public class NullLinkClient implements LinkClient {
     }
 
     @Override
-    public void patchLink(String companyNumber) {
+    public void patchLink(PatchLinkRequest linkRequest) {
         logger.error(String.format(
-                "Invalid delta type and/or event type for company number %s", companyNumber));
+                "Invalid delta type and/or event type for company number %s",
+                linkRequest.getCompanyNumber()));
         throw new NonRetryableErrorException("Invalid delta type and/or event type");
     }
 }

--- a/src/main/java/uk/gov/companieshouse/company/links/service/PatchLinkRequestExtractable.java
+++ b/src/main/java/uk/gov/companieshouse/company/links/service/PatchLinkRequestExtractable.java
@@ -2,6 +2,6 @@ package uk.gov.companieshouse.company.links.service;
 
 import uk.gov.companieshouse.company.links.type.PatchLinkRequest;
 
-public interface LinkClient {
-    void patchLink(PatchLinkRequest linkRequest);
+public interface PatchLinkRequestExtractable {
+    PatchLinkRequest extractPatchLinkRequest(String uri);
 }

--- a/src/main/java/uk/gov/companieshouse/company/links/service/PatchLinkRequestExtractor.java
+++ b/src/main/java/uk/gov/companieshouse/company/links/service/PatchLinkRequestExtractor.java
@@ -1,25 +1,28 @@
 package uk.gov.companieshouse.company.links.service;
 
+import static org.apache.commons.lang3.StringUtils.substringAfterLast;
+
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.stereotype.Component;
 import uk.gov.companieshouse.company.links.exception.NonRetryableErrorException;
+import uk.gov.companieshouse.company.links.type.PatchLinkRequest;
 import uk.gov.companieshouse.logging.Logger;
 
 @Component
-public class CompanyNumberExtractor implements CompanyNumberExtractable {
+public class PatchLinkRequestExtractor implements PatchLinkRequestExtractable {
     private static final String EXTRACT_COMPANY_NUMBER_PATTERN =
             "(?<=company/)([a-zA-Z0-9]{6,10})(?=/.*)";
 
     private final Logger logger;
 
-    public CompanyNumberExtractor(Logger logger) {
+    public PatchLinkRequestExtractor(Logger logger) {
         this.logger = logger;
     }
 
     @Override
-    public String extractCompanyNumber(String uri) {
+    public PatchLinkRequest extractPatchLinkRequest(String uri) {
         if (StringUtils.isBlank(uri)) {
             logger.error("Could not extract company number from empty or null resource uri");
             throw new NonRetryableErrorException(
@@ -29,7 +32,7 @@ public class CompanyNumberExtractor implements CompanyNumberExtractable {
         Pattern companyNo = Pattern.compile(EXTRACT_COMPANY_NUMBER_PATTERN);
         Matcher matcher = companyNo.matcher(uri);
         if (matcher.find()) {
-            return matcher.group();
+            return new PatchLinkRequest(matcher.group(), substringAfterLast(uri, "/"));
         } else {
             logger.error(String.format("Could not extract company number from uri "
                     + "%s ", uri));

--- a/src/main/java/uk/gov/companieshouse/company/links/service/PatchLinkRequestExtractor.java
+++ b/src/main/java/uk/gov/companieshouse/company/links/service/PatchLinkRequestExtractor.java
@@ -12,8 +12,9 @@ import uk.gov.companieshouse.logging.Logger;
 
 @Component
 public class PatchLinkRequestExtractor implements PatchLinkRequestExtractable {
-    private static final String EXTRACT_COMPANY_NUMBER_PATTERN =
-            "(?<=company/)([a-zA-Z0-9]{6,10})(?=/.*)";
+
+    private static final Pattern EXTRACT_COMPANY_NUMBER_PATTERN =
+            Pattern.compile("(?<=company/)([a-zA-Z0-9]{6,10})(?=/.*)");
 
     private final Logger logger;
 
@@ -29,8 +30,7 @@ public class PatchLinkRequestExtractor implements PatchLinkRequestExtractable {
                     "Could not extract company number from empty or null resource uri");
         }
         // matches up to 10 digits between company/ and /
-        Pattern companyNo = Pattern.compile(EXTRACT_COMPANY_NUMBER_PATTERN);
-        Matcher matcher = companyNo.matcher(uri);
+        Matcher matcher = EXTRACT_COMPANY_NUMBER_PATTERN.matcher(uri);
         if (matcher.find()) {
             return new PatchLinkRequest(matcher.group(), substringAfterLast(uri, "/"));
         } else {

--- a/src/main/java/uk/gov/companieshouse/company/links/service/RemoveOfficersClient.java
+++ b/src/main/java/uk/gov/companieshouse/company/links/service/RemoveOfficersClient.java
@@ -1,12 +1,9 @@
 package uk.gov.companieshouse.company.links.service;
 
-import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Component;
 import uk.gov.companieshouse.api.appointment.OfficerList;
-import uk.gov.companieshouse.api.error.ApiErrorResponseException;
-import uk.gov.companieshouse.api.handler.exception.URIValidationException;
-import uk.gov.companieshouse.company.links.exception.NonRetryableErrorException;
 import uk.gov.companieshouse.company.links.exception.RetryableErrorException;
+import uk.gov.companieshouse.company.links.type.PatchLinkRequest;
 import uk.gov.companieshouse.logging.Logger;
 
 @Component
@@ -15,9 +12,16 @@ public class RemoveOfficersClient implements LinkClient {
     private final AppointmentsListClient appointmentsListClient;
     private final RemoveOfficersLinkClient removeOfficersLinkClient;
 
+    /**
+     * Constructs a RemoveOfficersClient.
+     *
+     * @param logger                   Logger
+     * @param appointmentsListClient   AppointmentsListClient
+     * @param removeOfficersLinkClient RemoveOfficersLinkClient
+     */
     public RemoveOfficersClient(Logger logger,
-                                AppointmentsListClient appointmentsListClient,
-                                RemoveOfficersLinkClient removeOfficersLinkClient) {
+            AppointmentsListClient appointmentsListClient,
+            RemoveOfficersLinkClient removeOfficersLinkClient) {
         this.logger = logger;
         this.appointmentsListClient = appointmentsListClient;
         this.removeOfficersLinkClient = removeOfficersLinkClient;
@@ -27,44 +31,20 @@ public class RemoveOfficersClient implements LinkClient {
      * Sends a patch request to the remove officers link endpoint in the company profile api and
      * handles any error responses.
      *
-     * @param linkRequest
+     * @param linkRequest PatchLinkRequest
      */
     @Override
     public void patchLink(PatchLinkRequest linkRequest) {
-        try {
-
-            OfficerList officerList = appointmentsListClient.getAppointmentsList(companyNumber);
-            if (officerList.getTotalResults() == 0) {
-                removeOfficersLinkClient.patchLink(companyNumber);
-            } else {
-
-            }
-        } catch (ApiErrorResponseException ex) {
-            if (HttpStatus.valueOf(ex.getStatusCode()).is5xxServerError()) {
-                logger.error(String.format("Server error returned with status code: [%s] "
-                        + "processing remove officers link request", ex.getStatusCode()));
-                throw new RetryableErrorException("Server error returned when processing "
-                        + "remove officers link request", ex);
-            } else if (ex.getStatusCode() == 409) {
-                logger.info("HTTP 409 Conflict returned; "
-                        + "company profile does not have an officers link already");
-            } else if (ex.getStatusCode() == 404) {
-                logger.info("HTTP 404 Not Found returned; "
-                        + "company profile does not exist");
-            } else {
-                logger.error(String.format("remove officers client error returned with "
-                          + "status code: [%s] when processing remove officers link request",
-                        ex.getStatusCode()));
-                throw new NonRetryableErrorException("Client error returned when "
-                        + "processing remove officers link request", ex);
-            }
-        } catch (IllegalArgumentException ex) {
-            logger.error("Illegal argument exception caught when handling API response");
-            throw new RetryableErrorException("Server error returned when processing remove "
-                    + "officers link request", ex);
-        } catch (URIValidationException ex) {
-            logger.error("Invalid companyNumber specified when handling API request");
-            throw new NonRetryableErrorException("Invalid companyNumber specified", ex);
+        OfficerList officerList = appointmentsListClient.getAppointmentsList(
+                linkRequest.getCompanyNumber());
+        if (officerList.getTotalResults() == 0) {
+            removeOfficersLinkClient.patchLink(linkRequest);
+        } else {
+//            if (chargesData.getItems().stream().anyMatch(x ->
+//                    incomingChargeId.equals(x.getId()))) {
+//                throw new RetryableErrorException(String.format("Charge with id: %s is still not "
+//                        + "deleted", incomingChargeId));
+//            }
         }
     }
 }

--- a/src/main/java/uk/gov/companieshouse/company/links/service/RemoveOfficersClient.java
+++ b/src/main/java/uk/gov/companieshouse/company/links/service/RemoveOfficersClient.java
@@ -8,6 +8,7 @@ import uk.gov.companieshouse.logging.Logger;
 
 @Component
 public class RemoveOfficersClient implements LinkClient {
+
     private final Logger logger;
     private final AppointmentsListClient appointmentsListClient;
     private final RemoveOfficersLinkClient removeOfficersLinkClient;
@@ -40,11 +41,15 @@ public class RemoveOfficersClient implements LinkClient {
         if (officerList.getTotalResults() == 0) {
             removeOfficersLinkClient.patchLink(linkRequest);
         } else {
-//            if (chargesData.getItems().stream().anyMatch(x ->
-//                    incomingChargeId.equals(x.getId()))) {
-//                throw new RetryableErrorException(String.format("Charge with id: %s is still not "
-//                        + "deleted", incomingChargeId));
-//            }
+            if (officerList.getItems().stream()
+                    .anyMatch(officerSummary -> officerSummary.getLinks().getSelf()
+                            .endsWith(linkRequest.getResourceId()))) {
+                throw new RetryableErrorException(String.format("Officer with id: %s is still not "
+                        + "deleted", linkRequest.getResourceId()));
+            } else {
+                logger.debug(String.format("Officers for company number [%s] still exist",
+                        linkRequest.getCompanyNumber()));
+            }
         }
     }
 }

--- a/src/main/java/uk/gov/companieshouse/company/links/service/RemoveOfficersLinkClient.java
+++ b/src/main/java/uk/gov/companieshouse/company/links/service/RemoveOfficersLinkClient.java
@@ -1,13 +1,13 @@
 package uk.gov.companieshouse.company.links.service;
 
 import java.util.function.Supplier;
-
 import org.springframework.stereotype.Component;
 import uk.gov.companieshouse.api.InternalApiClient;
 import uk.gov.companieshouse.api.error.ApiErrorResponseException;
 import uk.gov.companieshouse.api.handler.exception.URIValidationException;
 import uk.gov.companieshouse.company.links.exception.NonRetryableErrorException;
 import uk.gov.companieshouse.company.links.exception.RetryableErrorException;
+import uk.gov.companieshouse.company.links.type.PatchLinkRequest;
 import uk.gov.companieshouse.logging.Logger;
 
 @Component
@@ -16,7 +16,7 @@ public class RemoveOfficersLinkClient implements LinkClient {
     private final Supplier<InternalApiClient> internalApiClientFactory;
 
     public RemoveOfficersLinkClient(Logger logger,
-                                Supplier<InternalApiClient> internalApiClientFactory) {
+            Supplier<InternalApiClient> internalApiClientFactory) {
         this.logger = logger;
         this.internalApiClientFactory = internalApiClientFactory;
     }
@@ -25,7 +25,7 @@ public class RemoveOfficersLinkClient implements LinkClient {
      * Sends a patch request to the remove officers link endpoint in the company profile api and
      * handles any error responses.
      *
-     * @param linkRequest
+     * @param linkRequest PatchLinkRequest
      */
     @Override
     public void patchLink(PatchLinkRequest linkRequest) {
@@ -33,7 +33,8 @@ public class RemoveOfficersLinkClient implements LinkClient {
         try {
             client.privateCompanyLinksResourceHandler()
                     .removeOfficersCompanyLink(
-                            String.format("/company/%s/links/officers/delete", companyNumber))
+                            String.format("/company/%s/links/officers/delete",
+                                    linkRequest.getCompanyNumber()))
                     .execute();
         } catch (ApiErrorResponseException ex) {
             if (ex.getStatusCode() / 100 == 5) {
@@ -49,7 +50,7 @@ public class RemoveOfficersLinkClient implements LinkClient {
                         + "company profile does not exist");
             } else {
                 logger.error(String.format("remove officers client error returned with "
-                          + "status code: [%s] when processing remove officers link request",
+                                + "status code: [%s] when processing remove officers link request",
                         ex.getStatusCode()));
                 throw new NonRetryableErrorException("Client error returned when "
                         + "processing remove officers link request", ex);

--- a/src/main/java/uk/gov/companieshouse/company/links/type/PatchLinkRequest.java
+++ b/src/main/java/uk/gov/companieshouse/company/links/type/PatchLinkRequest.java
@@ -1,0 +1,24 @@
+package uk.gov.companieshouse.company.links.type;
+
+public class PatchLinkRequest {
+    private final String companyNumber;
+    private final String resourceId;
+
+    public PatchLinkRequest(String companyNumber, String resourceId) {
+        this.companyNumber = companyNumber;
+        this.resourceId = resourceId;
+    }
+
+    public PatchLinkRequest(String companyNumber) {
+        this.companyNumber = companyNumber;
+        this.resourceId = null;
+    }
+
+    public String getCompanyNumber() {
+        return companyNumber;
+    }
+
+    public String getResourceId() {
+        return resourceId;
+    }
+}

--- a/src/test/java/uk/gov/companieshouse/company/links/service/AddExemptionsClientTest.java
+++ b/src/test/java/uk/gov/companieshouse/company/links/service/AddExemptionsClientTest.java
@@ -23,6 +23,7 @@ import uk.gov.companieshouse.api.handler.exception.URIValidationException;
 import uk.gov.companieshouse.api.model.ApiResponse;
 import uk.gov.companieshouse.company.links.exception.NonRetryableErrorException;
 import uk.gov.companieshouse.company.links.exception.RetryableErrorException;
+import uk.gov.companieshouse.company.links.type.PatchLinkRequest;
 import uk.gov.companieshouse.logging.Logger;
 
 @ExtendWith(MockitoExtension.class)
@@ -49,6 +50,7 @@ class AddExemptionsClientTest {
     @InjectMocks
     private AddExemptionsClient client;
 
+    private final PatchLinkRequest linkRequest = new PatchLinkRequest(COMPANY_NUMBER);
 
     @Test
     void testUpsert() throws ApiErrorResponseException, URIValidationException {
@@ -59,7 +61,7 @@ class AddExemptionsClientTest {
         when(exemptionsLinksPatchHandler.execute()).thenReturn(new ApiResponse<>(200, Collections.emptyMap()));
 
         // when
-        client.patchLink(COMPANY_NUMBER);
+        client.patchLink(linkRequest);
 
         // then
         verify(resourceHandler).addExemptionsCompanyLink(PATH);
@@ -75,7 +77,7 @@ class AddExemptionsClientTest {
         when(exemptionsLinksPatchHandler.execute()).thenThrow(new ApiErrorResponseException(new HttpResponseException.Builder(404, "Not found", new HttpHeaders())));
 
         // when
-        client.patchLink(COMPANY_NUMBER);
+        client.patchLink(linkRequest);
 
         // then
         verify(resourceHandler).addExemptionsCompanyLink(PATH);
@@ -92,7 +94,7 @@ class AddExemptionsClientTest {
         when(exemptionsLinksPatchHandler.execute()).thenThrow(new ApiErrorResponseException(new HttpResponseException.Builder(409, "Conflict", new HttpHeaders())));
 
         // when
-        client.patchLink(COMPANY_NUMBER);
+        client.patchLink(linkRequest);
 
         // then
         verify(resourceHandler).addExemptionsCompanyLink(PATH);
@@ -109,7 +111,7 @@ class AddExemptionsClientTest {
         when(exemptionsLinksPatchHandler.execute()).thenThrow(new ApiErrorResponseException(new HttpResponseException.Builder(500, "Internal server error", new HttpHeaders())));
 
         // when
-        Executable actual = () -> client.patchLink(COMPANY_NUMBER);
+        Executable actual = () -> client.patchLink(linkRequest);
 
         // then
         assertThrows(RetryableErrorException.class, actual);
@@ -126,7 +128,7 @@ class AddExemptionsClientTest {
         when(exemptionsLinksPatchHandler.execute()).thenThrow(new IllegalArgumentException("Internal server error"));
 
         // when
-        Executable actual = () -> client.patchLink(COMPANY_NUMBER);
+        Executable actual = () -> client.patchLink(linkRequest);
 
         // then
         assertThrows(RetryableErrorException.class, actual);
@@ -143,7 +145,7 @@ class AddExemptionsClientTest {
         when(exemptionsLinksPatchHandler.execute()).thenThrow(new URIValidationException("Invalid URI"));
 
         // when
-        Executable actual = () -> client.patchLink("invalid/path");
+        Executable actual = () -> client.patchLink(new PatchLinkRequest("invalid/path"));
 
         // then
         assertThrows(NonRetryableErrorException.class, actual);

--- a/src/test/java/uk/gov/companieshouse/company/links/service/AddOfficersClientTest.java
+++ b/src/test/java/uk/gov/companieshouse/company/links/service/AddOfficersClientTest.java
@@ -19,6 +19,7 @@ import uk.gov.companieshouse.api.handler.exception.URIValidationException;
 import uk.gov.companieshouse.api.model.ApiResponse;
 import uk.gov.companieshouse.company.links.exception.NonRetryableErrorException;
 import uk.gov.companieshouse.company.links.exception.RetryableErrorException;
+import uk.gov.companieshouse.company.links.type.PatchLinkRequest;
 import uk.gov.companieshouse.logging.Logger;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -49,6 +50,8 @@ class AddOfficersClientTest {
     @InjectMocks
     private AddOfficersClient client;
 
+    private final PatchLinkRequest linkRequest = new PatchLinkRequest(COMPANY_NUMBER);
+
     @Test
     void testUpsert() throws ApiErrorResponseException, URIValidationException {
         // given
@@ -58,7 +61,7 @@ class AddOfficersClientTest {
         when(officersLinksAddHandler.execute()).thenReturn(new ApiResponse<>(200, Collections.emptyMap()));
 
         // when
-        client.patchLink(COMPANY_NUMBER);
+        client.patchLink(linkRequest);
 
         // then
         verify(resourceHandler).addOfficersCompanyLink(PATH);
@@ -74,7 +77,7 @@ class AddOfficersClientTest {
         when(officersLinksAddHandler.execute()).thenThrow(new ApiErrorResponseException(new HttpResponseException.Builder(404, "Not found", new HttpHeaders())));
 
         // when
-        client.patchLink(COMPANY_NUMBER);
+        client.patchLink(linkRequest);
 
         // then
         verify(resourceHandler).addOfficersCompanyLink(PATH);
@@ -91,7 +94,7 @@ class AddOfficersClientTest {
         when(officersLinksAddHandler.execute()).thenThrow(new ApiErrorResponseException(new HttpResponseException.Builder(409, "Conflict", new HttpHeaders())));
 
         // when
-        client.patchLink(COMPANY_NUMBER);
+        client.patchLink(linkRequest);
 
         // then
         verify(resourceHandler).addOfficersCompanyLink(PATH);
@@ -108,7 +111,7 @@ class AddOfficersClientTest {
         when(officersLinksAddHandler.execute()).thenThrow(new ApiErrorResponseException(new HttpResponseException.Builder(500, "Internal server error", new HttpHeaders())));
 
         // when
-        Executable actual = () -> client.patchLink(COMPANY_NUMBER);
+        Executable actual = () -> client.patchLink(linkRequest);
 
         // then
         assertThrows(RetryableErrorException.class, actual);
@@ -125,7 +128,7 @@ class AddOfficersClientTest {
         when(officersLinksAddHandler.execute()).thenThrow(new IllegalArgumentException("Internal server error"));
 
         // when
-        Executable actual = () -> client.patchLink(COMPANY_NUMBER);
+        Executable actual = () -> client.patchLink(linkRequest);
 
         // then
         assertThrows(RetryableErrorException.class, actual);
@@ -142,7 +145,7 @@ class AddOfficersClientTest {
         when(officersLinksAddHandler.execute()).thenThrow(new URIValidationException("Invalid URI"));
 
         // when
-        Executable actual = () -> client.patchLink("invalid/path");
+        Executable actual = () -> client.patchLink(new PatchLinkRequest("invalid/path"));
 
         // then
         assertThrows(NonRetryableErrorException.class, actual);

--- a/src/test/java/uk/gov/companieshouse/company/links/service/AppointmentsListClientTest.java
+++ b/src/test/java/uk/gov/companieshouse/company/links/service/AppointmentsListClientTest.java
@@ -1,0 +1,179 @@
+package uk.gov.companieshouse.company.links.service;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.http.HttpStatus.BAD_REQUEST;
+import static org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR;
+import static org.springframework.http.HttpStatus.NOT_FOUND;
+
+import com.google.api.client.http.HttpHeaders;
+import com.google.api.client.http.HttpResponseException;
+import java.util.Collections;
+import java.util.function.Supplier;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.function.Executable;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.companieshouse.api.InternalApiClient;
+import uk.gov.companieshouse.api.appointment.OfficerList;
+import uk.gov.companieshouse.api.error.ApiErrorResponseException;
+import uk.gov.companieshouse.api.handler.appointment.PrivateCompanyAppointmentsList;
+import uk.gov.companieshouse.api.handler.appointment.PrivateCompanyAppointmentsListHandler;
+import uk.gov.companieshouse.api.handler.exception.URIValidationException;
+import uk.gov.companieshouse.api.model.ApiResponse;
+import uk.gov.companieshouse.company.links.exception.NonRetryableErrorException;
+import uk.gov.companieshouse.company.links.exception.RetryableErrorException;
+import uk.gov.companieshouse.logging.Logger;
+
+@ExtendWith(MockitoExtension.class)
+class AppointmentsListClientTest {
+
+    private static final String COMPANY_NUMBER = "12345678";
+
+    private static final String PATH = String.format("/company/%s/officers-test", COMPANY_NUMBER);
+
+    @Mock
+    private Supplier<InternalApiClient> internalApiClientSupplier;
+
+    @Mock
+    private InternalApiClient internalApiClient;
+
+    @Mock
+    private PrivateCompanyAppointmentsListHandler resourceHandler;
+
+    @Mock
+    private PrivateCompanyAppointmentsList privateCompanyAppointmentsList;
+
+    @Mock
+    private Logger logger;
+
+    @Mock
+    private HttpResponseException httpResponseException;
+
+    @InjectMocks
+    private AppointmentsListClient client;
+
+    @Test
+    void shouldReturnOfficerList() throws Exception {
+        // given
+        when(internalApiClientSupplier.get()).thenReturn(internalApiClient);
+        when(internalApiClient.privateCompanyAppointmentsListHandler()).thenReturn(resourceHandler);
+        when(resourceHandler.getCompanyAppointmentsList(anyString())).thenReturn(
+                privateCompanyAppointmentsList);
+        when(privateCompanyAppointmentsList.execute()).thenReturn(
+                new ApiResponse<>(200, Collections.emptyMap(),
+                        new OfficerList()
+                                .totalResults(0)));
+
+        // when
+        OfficerList officerList = client.getAppointmentsList(COMPANY_NUMBER);
+
+        // then
+        verify(resourceHandler).getCompanyAppointmentsList(PATH);
+        verify(privateCompanyAppointmentsList).execute();
+        assertThat(officerList).isNotNull();
+        assertThat(officerList.getTotalResults()).isZero();
+    }
+
+    @Test
+    void shouldThrowApiErrorResponseExceptionWhenServerError() throws Exception {
+        // given
+        when(internalApiClientSupplier.get()).thenReturn(internalApiClient);
+        when(internalApiClient.privateCompanyAppointmentsListHandler()).thenReturn(resourceHandler);
+        when(resourceHandler.getCompanyAppointmentsList(anyString())).thenReturn(
+                privateCompanyAppointmentsList);
+        when(privateCompanyAppointmentsList.execute())
+                .thenThrow(new ApiErrorResponseException(
+                        new HttpResponseException
+                                .Builder(INTERNAL_SERVER_ERROR.value(),
+                                "Internal server error", new HttpHeaders())));
+
+        Executable actual = () -> client.getAppointmentsList(COMPANY_NUMBER);
+
+        Exception ex = assertThrows(RetryableErrorException.class, actual);
+        assertThat(ex.getMessage())
+                .isEqualTo("Server error status code: "
+                        + "[500] while fetching appointments list for company 12345678");
+    }
+
+    @Test
+    void shouldReturnOfficerListWithTotalCountZeroWhenNotFound() throws Exception {
+        // given
+        when(internalApiClientSupplier.get()).thenReturn(internalApiClient);
+        when(internalApiClient.privateCompanyAppointmentsListHandler()).thenReturn(resourceHandler);
+        when(resourceHandler.getCompanyAppointmentsList(anyString())).thenReturn(
+                privateCompanyAppointmentsList);
+        when(privateCompanyAppointmentsList.execute())
+                .thenThrow(new ApiErrorResponseException(
+                        new HttpResponseException
+                                .Builder(NOT_FOUND.value(),
+                                "Not found", new HttpHeaders())));
+
+        OfficerList officerList = client.getAppointmentsList(COMPANY_NUMBER);
+
+        verify(resourceHandler).getCompanyAppointmentsList(PATH);
+        verify(privateCompanyAppointmentsList).execute();
+        assertThat(officerList).isNotNull();
+        assertThat(officerList.getTotalResults()).isZero();
+    }
+
+    @Test
+    void shouldThrowApiErrorResponseExceptionWhenClientError() throws Exception {
+        // given
+        when(internalApiClientSupplier.get()).thenReturn(internalApiClient);
+        when(internalApiClient.privateCompanyAppointmentsListHandler()).thenReturn(resourceHandler);
+        when(resourceHandler.getCompanyAppointmentsList(anyString())).thenReturn(
+                privateCompanyAppointmentsList);
+        when(privateCompanyAppointmentsList.execute())
+                .thenThrow(new ApiErrorResponseException(
+                        new HttpResponseException
+                                .Builder(BAD_REQUEST.value(),
+                                "Bad request", new HttpHeaders())));
+
+        Executable actual = () -> client.getAppointmentsList(COMPANY_NUMBER);
+
+        Exception ex = assertThrows(NonRetryableErrorException.class, actual);
+        assertThat(ex.getMessage())
+                .isEqualTo("Client error status code: [400] "
+                        + "while fetching appointments list");
+    }
+
+    @Test
+    void shouldThrowRetryableErrorExceptionWhenIllegalArgumentThrownByApi() throws Exception {
+        // given
+        when(internalApiClientSupplier.get()).thenReturn(internalApiClient);
+        when(internalApiClient.privateCompanyAppointmentsListHandler()).thenReturn(resourceHandler);
+        when(resourceHandler.getCompanyAppointmentsList(anyString())).thenReturn(
+                privateCompanyAppointmentsList);
+        when(privateCompanyAppointmentsList.execute())
+                .thenThrow(new IllegalArgumentException());
+
+        Executable actual = () -> client.getAppointmentsList(COMPANY_NUMBER);
+
+        Exception ex = assertThrows(RetryableErrorException.class, actual);
+        assertThat(ex.getMessage())
+                .isEqualTo("Error returned when fetching appointments");
+    }
+
+    @Test
+    void shouldThrowNonRetryableErrorExceptionWhenURIValidationExceptionThrownByApi() throws Exception {
+        // given
+        when(internalApiClientSupplier.get()).thenReturn(internalApiClient);
+        when(internalApiClient.privateCompanyAppointmentsListHandler()).thenReturn(resourceHandler);
+        when(resourceHandler.getCompanyAppointmentsList(anyString())).thenReturn(
+                privateCompanyAppointmentsList);
+        when(privateCompanyAppointmentsList.execute())
+                .thenThrow(new URIValidationException("URI wrong"));
+
+        Executable actual = () -> client.getAppointmentsList(COMPANY_NUMBER);
+
+        Exception ex = assertThrows(NonRetryableErrorException.class, actual);
+        assertThat(ex.getMessage())
+                .isEqualTo("Invalid companyNumber [12345678] when handling API request");
+    }
+}

--- a/src/test/java/uk/gov/companieshouse/company/links/service/AppointmentsListClientTest.java
+++ b/src/test/java/uk/gov/companieshouse/company/links/service/AppointmentsListClientTest.java
@@ -13,6 +13,7 @@ import com.google.api.client.http.HttpHeaders;
 import com.google.api.client.http.HttpResponseException;
 import java.util.Collections;
 import java.util.function.Supplier;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.function.Executable;
@@ -55,13 +56,17 @@ class AppointmentsListClientTest {
     @InjectMocks
     private AppointmentsListClient client;
 
-    @Test
-    void shouldReturnOfficerList() throws Exception {
-        // given
+    @BeforeEach
+    void setup() {
         when(internalApiClientSupplier.get()).thenReturn(internalApiClient);
         when(internalApiClient.privateCompanyAppointmentsListHandler()).thenReturn(resourceHandler);
         when(resourceHandler.getCompanyAppointmentsList(anyString())).thenReturn(
                 privateCompanyAppointmentsList);
+    }
+
+    @Test
+    void shouldReturnOfficerList() throws Exception {
+        // given
         when(privateCompanyAppointmentsList.execute()).thenReturn(
                 new ApiResponse<>(200, Collections.emptyMap(),
                         new OfficerList()
@@ -80,10 +85,6 @@ class AppointmentsListClientTest {
     @Test
     void shouldThrowApiErrorResponseExceptionWhenServerError() throws Exception {
         // given
-        when(internalApiClientSupplier.get()).thenReturn(internalApiClient);
-        when(internalApiClient.privateCompanyAppointmentsListHandler()).thenReturn(resourceHandler);
-        when(resourceHandler.getCompanyAppointmentsList(anyString())).thenReturn(
-                privateCompanyAppointmentsList);
         when(privateCompanyAppointmentsList.execute())
                 .thenThrow(new ApiErrorResponseException(
                         new HttpResponseException
@@ -101,10 +102,6 @@ class AppointmentsListClientTest {
     @Test
     void shouldReturnOfficerListWithTotalCountZeroWhenNotFound() throws Exception {
         // given
-        when(internalApiClientSupplier.get()).thenReturn(internalApiClient);
-        when(internalApiClient.privateCompanyAppointmentsListHandler()).thenReturn(resourceHandler);
-        when(resourceHandler.getCompanyAppointmentsList(anyString())).thenReturn(
-                privateCompanyAppointmentsList);
         when(privateCompanyAppointmentsList.execute())
                 .thenThrow(new ApiErrorResponseException(
                         new HttpResponseException
@@ -123,10 +120,6 @@ class AppointmentsListClientTest {
     @Test
     void shouldThrowRetryableErrorExceptionWhenAppointmentsApiIsDown() throws Exception {
         // given
-        when(internalApiClientSupplier.get()).thenReturn(internalApiClient);
-        when(internalApiClient.privateCompanyAppointmentsListHandler()).thenReturn(resourceHandler);
-        when(resourceHandler.getCompanyAppointmentsList(anyString())).thenReturn(
-                privateCompanyAppointmentsList);
         when(privateCompanyAppointmentsList.execute())
                 .thenThrow(new ApiErrorResponseException(
                         new HttpResponseException
@@ -145,10 +138,6 @@ class AppointmentsListClientTest {
     @Test
     void shouldThrowApiErrorResponseExceptionWhenClientError() throws Exception {
         // given
-        when(internalApiClientSupplier.get()).thenReturn(internalApiClient);
-        when(internalApiClient.privateCompanyAppointmentsListHandler()).thenReturn(resourceHandler);
-        when(resourceHandler.getCompanyAppointmentsList(anyString())).thenReturn(
-                privateCompanyAppointmentsList);
         when(privateCompanyAppointmentsList.execute())
                 .thenThrow(new ApiErrorResponseException(
                         new HttpResponseException
@@ -166,10 +155,6 @@ class AppointmentsListClientTest {
     @Test
     void shouldThrowRetryableErrorExceptionWhenIllegalArgumentThrownByApi() throws Exception {
         // given
-        when(internalApiClientSupplier.get()).thenReturn(internalApiClient);
-        when(internalApiClient.privateCompanyAppointmentsListHandler()).thenReturn(resourceHandler);
-        when(resourceHandler.getCompanyAppointmentsList(anyString())).thenReturn(
-                privateCompanyAppointmentsList);
         when(privateCompanyAppointmentsList.execute())
                 .thenThrow(new IllegalArgumentException());
 
@@ -183,10 +168,6 @@ class AppointmentsListClientTest {
     @Test
     void shouldThrowNonRetryableErrorExceptionWhenURIValidationExceptionThrownByApi() throws Exception {
         // given
-        when(internalApiClientSupplier.get()).thenReturn(internalApiClient);
-        when(internalApiClient.privateCompanyAppointmentsListHandler()).thenReturn(resourceHandler);
-        when(resourceHandler.getCompanyAppointmentsList(anyString())).thenReturn(
-                privateCompanyAppointmentsList);
         when(privateCompanyAppointmentsList.execute())
                 .thenThrow(new URIValidationException("URI wrong"));
 

--- a/src/test/java/uk/gov/companieshouse/company/links/service/CompanyNumberExtractorTest.java
+++ b/src/test/java/uk/gov/companieshouse/company/links/service/CompanyNumberExtractorTest.java
@@ -25,14 +25,14 @@ class CompanyNumberExtractorTest {
     private Logger logger;
 
     @InjectMocks
-    private CompanyNumberExtractor extractor;
+    private PatchLinkRequestExtractor extractor;
 
     @Test
     @DisplayName("The extractor should get the correct company number back")
     void process() {
         // given
         // when
-        String actual = extractor.extractCompanyNumber("company/OC305127/appointments/-0YatipCW4ZL295N9UVFo1TGyW8");
+        String actual = extractor.extractPatchLinkRequest("company/OC305127/appointments/-0YatipCW4ZL295N9UVFo1TGyW8");
 
         // then
         assertEquals("OC305127", actual);
@@ -44,7 +44,7 @@ class CompanyNumberExtractorTest {
         // given
 
         // when
-        Executable executable = () -> extractor.extractCompanyNumber(uri);
+        Executable executable = () -> extractor.extractPatchLinkRequest(uri);
 
         // then
         Exception exception = assertThrows(NonRetryableErrorException.class, executable);

--- a/src/test/java/uk/gov/companieshouse/company/links/service/CompanyNumberExtractorTest.java
+++ b/src/test/java/uk/gov/companieshouse/company/links/service/CompanyNumberExtractorTest.java
@@ -12,6 +12,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.companieshouse.company.links.exception.NonRetryableErrorException;
+import uk.gov.companieshouse.company.links.type.PatchLinkRequest;
 import uk.gov.companieshouse.logging.Logger;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -32,10 +33,10 @@ class CompanyNumberExtractorTest {
     void process() {
         // given
         // when
-        String actual = extractor.extractPatchLinkRequest("company/OC305127/appointments/-0YatipCW4ZL295N9UVFo1TGyW8");
+        PatchLinkRequest actual = extractor.extractPatchLinkRequest("company/OC305127/appointments/-0YatipCW4ZL295N9UVFo1TGyW8");
 
         // then
-        assertEquals("OC305127", actual);
+        assertEquals("OC305127", actual.getCompanyNumber());
     }
 
     @ParameterizedTest(name = "{index}: {0}")

--- a/src/test/java/uk/gov/companieshouse/company/links/service/DeleteExemptionsClientTest.java
+++ b/src/test/java/uk/gov/companieshouse/company/links/service/DeleteExemptionsClientTest.java
@@ -16,6 +16,7 @@ import uk.gov.companieshouse.api.handler.exception.URIValidationException;
 import uk.gov.companieshouse.api.model.ApiResponse;
 import uk.gov.companieshouse.company.links.exception.NonRetryableErrorException;
 import uk.gov.companieshouse.company.links.exception.RetryableErrorException;
+import uk.gov.companieshouse.company.links.type.PatchLinkRequest;
 import uk.gov.companieshouse.logging.Logger;
 
 import java.util.Collections;
@@ -50,6 +51,8 @@ class DeleteExemptionsClientTest {
     @InjectMocks
     private DeleteExemptionsClient client;
 
+    private final PatchLinkRequest linkRequest = new PatchLinkRequest(COMPANY_NUMBER);
+
     @Test
     void testDelete() throws ApiErrorResponseException, URIValidationException {
         // given
@@ -59,7 +62,7 @@ class DeleteExemptionsClientTest {
         when(exemptionsLinksDelete.execute()).thenReturn(new ApiResponse<>(200, Collections.emptyMap()));
 
         // when
-        client.patchLink(COMPANY_NUMBER);
+        client.patchLink(linkRequest);
 
         // then
         verify(resourceHandler).deleteExemptionsCompanyLink(PATH);
@@ -75,7 +78,7 @@ class DeleteExemptionsClientTest {
         when(exemptionsLinksDelete.execute()).thenThrow(new ApiErrorResponseException(new HttpResponseException.Builder(404, "Not found", new HttpHeaders())));
 
         // when
-        client.patchLink(COMPANY_NUMBER);
+        client.patchLink(linkRequest);
 
         // then
         verify(resourceHandler).deleteExemptionsCompanyLink(PATH);
@@ -92,7 +95,7 @@ class DeleteExemptionsClientTest {
         when(exemptionsLinksDelete.execute()).thenThrow(new ApiErrorResponseException(new HttpResponseException.Builder(409, "Conflict", new HttpHeaders())));
 
         // when
-        client.patchLink(COMPANY_NUMBER);
+        client.patchLink(linkRequest);
 
         // then
         verify(resourceHandler).deleteExemptionsCompanyLink(PATH);
@@ -109,7 +112,7 @@ class DeleteExemptionsClientTest {
         when(exemptionsLinksDelete.execute()).thenThrow(new ApiErrorResponseException(new HttpResponseException.Builder(500, "Internal server error", new HttpHeaders())));
 
         // when
-        Executable actual = () -> client.patchLink(COMPANY_NUMBER);
+        Executable actual = () -> client.patchLink(linkRequest);
 
         // then
         assertThrows(RetryableErrorException.class, actual);
@@ -126,7 +129,7 @@ class DeleteExemptionsClientTest {
         when(exemptionsLinksDelete.execute()).thenThrow(new IllegalArgumentException("Internal server error"));
 
         // when
-        Executable actual = () -> client.patchLink(COMPANY_NUMBER);
+        Executable actual = () -> client.patchLink(linkRequest);
 
         // then
         assertThrows(RetryableErrorException.class, actual);
@@ -143,7 +146,7 @@ class DeleteExemptionsClientTest {
         when(exemptionsLinksDelete.execute()).thenThrow(new URIValidationException("Invalid URI"));
 
         // when
-        Executable actual = () -> client.patchLink("invalid/companyNumber");
+        Executable actual = () -> client.patchLink(new PatchLinkRequest("invalid/companyNumber"));
 
         // then
         assertThrows(NonRetryableErrorException.class, actual);

--- a/src/test/java/uk/gov/companieshouse/company/links/service/LinkClientFactoryTest.java
+++ b/src/test/java/uk/gov/companieshouse/company/links/service/LinkClientFactoryTest.java
@@ -54,7 +54,7 @@ class LinkClientFactoryTest {
         LinkClient linkClient = factory.getLinkClient("officers", "deleted");
 
         // then
-        assertTrue(linkClient instanceof RemoveOfficersClient);
+        assertTrue(linkClient instanceof RemoveOfficersLinkClient);
     }
 
     @Test

--- a/src/test/java/uk/gov/companieshouse/company/links/service/LinkClientFactoryTest.java
+++ b/src/test/java/uk/gov/companieshouse/company/links/service/LinkClientFactoryTest.java
@@ -1,7 +1,5 @@
 package uk.gov.companieshouse.company.links.service;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.core.Is.is;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.junit.jupiter.api.DisplayName;

--- a/src/test/java/uk/gov/companieshouse/company/links/service/LinkClientFactoryTest.java
+++ b/src/test/java/uk/gov/companieshouse/company/links/service/LinkClientFactoryTest.java
@@ -1,5 +1,7 @@
 package uk.gov.companieshouse.company.links.service;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.junit.jupiter.api.DisplayName;
@@ -54,7 +56,7 @@ class LinkClientFactoryTest {
         LinkClient linkClient = factory.getLinkClient("officers", "deleted");
 
         // then
-        assertTrue(linkClient instanceof RemoveOfficersLinkClient);
+        assertTrue(linkClient instanceof RemoveOfficersClient);
     }
 
     @Test

--- a/src/test/java/uk/gov/companieshouse/company/links/service/LinkRouterTest.java
+++ b/src/test/java/uk/gov/companieshouse/company/links/service/LinkRouterTest.java
@@ -11,6 +11,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.companieshouse.company.links.processor.LinkRouter;
+import uk.gov.companieshouse.company.links.type.PatchLinkRequest;
 import uk.gov.companieshouse.company.links.type.ResourceChange;
 import uk.gov.companieshouse.stream.EventRecord;
 import uk.gov.companieshouse.stream.ResourceChangedData;
@@ -47,6 +48,9 @@ class LinkRouterTest {
     @Mock
     private EventRecord event;
 
+    @Mock
+    private PatchLinkRequest linkRequest;
+
     @BeforeEach
     void setup() {
         router = new LinkRouter(extractor, factory);
@@ -60,7 +64,7 @@ class LinkRouterTest {
         when(data.getEvent()).thenReturn(event);
         when(event.getType()).thenReturn("changed");
         when(data.getResourceUri()).thenReturn("company/12345678/exemptions");
-        when(extractor.extractPatchLinkRequest(any())).thenReturn("12345678");
+        when(extractor.extractPatchLinkRequest(any())).thenReturn(linkRequest);
         when(factory.getLinkClient(any(), any())).thenReturn(addExemptionsClient);
 
         // when
@@ -68,7 +72,7 @@ class LinkRouterTest {
 
         // then
         verify(extractor).extractPatchLinkRequest("company/12345678/exemptions");
-        verify(addExemptionsClient).patchLink("12345678");
+        verify(addExemptionsClient).patchLink(linkRequest);
     }
 
     @Test
@@ -79,7 +83,7 @@ class LinkRouterTest {
         when(data.getEvent()).thenReturn(event);
         when(event.getType()).thenReturn("deleted");
         when(data.getResourceUri()).thenReturn("company/12345678/exemptions");
-        when(extractor.extractPatchLinkRequest(any())).thenReturn("12345678");
+        when(extractor.extractPatchLinkRequest(any())).thenReturn(linkRequest);
         when(factory.getLinkClient(any(), any())).thenReturn(deleteExemptionsClient);
 
         // when
@@ -87,7 +91,7 @@ class LinkRouterTest {
 
         // then
         verify(extractor).extractPatchLinkRequest("company/12345678/exemptions");
-        verify(deleteExemptionsClient).patchLink("12345678");
+        verify(deleteExemptionsClient).patchLink(linkRequest);
     }
 
     @Test
@@ -98,7 +102,7 @@ class LinkRouterTest {
         when(data.getEvent()).thenReturn(event);
         when(event.getType()).thenReturn("changed");
         when(data.getResourceUri()).thenReturn("company/12345678/officers");
-        when(extractor.extractPatchLinkRequest(any())).thenReturn("12345678");
+        when(extractor.extractPatchLinkRequest(any())).thenReturn(linkRequest);
         when(factory.getLinkClient(any(), any())).thenReturn(addOfficersClient);
 
         // when
@@ -106,7 +110,7 @@ class LinkRouterTest {
 
         // then
         verify(extractor).extractPatchLinkRequest("company/12345678/officers");
-        verify(addOfficersClient).patchLink("12345678");
+        verify(addOfficersClient).patchLink(linkRequest);
     }
 
     @Test
@@ -117,7 +121,7 @@ class LinkRouterTest {
         when(data.getEvent()).thenReturn(event);
         when(event.getType()).thenReturn("deleted");
         when(data.getResourceUri()).thenReturn("company/12345678/officers");
-        when(extractor.extractPatchLinkRequest(any())).thenReturn("12345678");
+        when(extractor.extractPatchLinkRequest(any())).thenReturn(linkRequest);
         when(factory.getLinkClient(any(), any())).thenReturn(removeOfficersLinkClient);
 
         // when
@@ -125,6 +129,6 @@ class LinkRouterTest {
 
         // then
         verify(extractor).extractPatchLinkRequest("company/12345678/officers");
-        verify(removeOfficersLinkClient).patchLink("12345678");
+        verify(removeOfficersLinkClient).patchLink(linkRequest);
     }
 }

--- a/src/test/java/uk/gov/companieshouse/company/links/service/LinkRouterTest.java
+++ b/src/test/java/uk/gov/companieshouse/company/links/service/LinkRouterTest.java
@@ -19,7 +19,7 @@ import uk.gov.companieshouse.stream.ResourceChangedData;
 class LinkRouterTest {
 
     @Mock
-    private CompanyNumberExtractable extractor;
+    private PatchLinkRequestExtractable extractor;
 
     @Mock
     private LinkClientFactory factory;
@@ -34,7 +34,7 @@ class LinkRouterTest {
     private AddOfficersClient addOfficersClient;
 
     @Mock
-    private RemoveOfficersClient removeOfficersClient;
+    private RemoveOfficersLinkClient removeOfficersLinkClient;
 
     private LinkRouter router;
 
@@ -60,14 +60,14 @@ class LinkRouterTest {
         when(data.getEvent()).thenReturn(event);
         when(event.getType()).thenReturn("changed");
         when(data.getResourceUri()).thenReturn("company/12345678/exemptions");
-        when(extractor.extractCompanyNumber(any())).thenReturn("12345678");
+        when(extractor.extractPatchLinkRequest(any())).thenReturn("12345678");
         when(factory.getLinkClient(any(), any())).thenReturn(addExemptionsClient);
 
         // when
         router.route(message, "deltaType");
 
         // then
-        verify(extractor).extractCompanyNumber("company/12345678/exemptions");
+        verify(extractor).extractPatchLinkRequest("company/12345678/exemptions");
         verify(addExemptionsClient).patchLink("12345678");
     }
 
@@ -79,14 +79,14 @@ class LinkRouterTest {
         when(data.getEvent()).thenReturn(event);
         when(event.getType()).thenReturn("deleted");
         when(data.getResourceUri()).thenReturn("company/12345678/exemptions");
-        when(extractor.extractCompanyNumber(any())).thenReturn("12345678");
+        when(extractor.extractPatchLinkRequest(any())).thenReturn("12345678");
         when(factory.getLinkClient(any(), any())).thenReturn(deleteExemptionsClient);
 
         // when
         router.route(message, "deltaType");
 
         // then
-        verify(extractor).extractCompanyNumber("company/12345678/exemptions");
+        verify(extractor).extractPatchLinkRequest("company/12345678/exemptions");
         verify(deleteExemptionsClient).patchLink("12345678");
     }
 
@@ -98,14 +98,14 @@ class LinkRouterTest {
         when(data.getEvent()).thenReturn(event);
         when(event.getType()).thenReturn("changed");
         when(data.getResourceUri()).thenReturn("company/12345678/officers");
-        when(extractor.extractCompanyNumber(any())).thenReturn("12345678");
+        when(extractor.extractPatchLinkRequest(any())).thenReturn("12345678");
         when(factory.getLinkClient(any(), any())).thenReturn(addOfficersClient);
 
         // when
         router.route(message, "deltaType");
 
         // then
-        verify(extractor).extractCompanyNumber("company/12345678/officers");
+        verify(extractor).extractPatchLinkRequest("company/12345678/officers");
         verify(addOfficersClient).patchLink("12345678");
     }
 
@@ -117,14 +117,14 @@ class LinkRouterTest {
         when(data.getEvent()).thenReturn(event);
         when(event.getType()).thenReturn("deleted");
         when(data.getResourceUri()).thenReturn("company/12345678/officers");
-        when(extractor.extractCompanyNumber(any())).thenReturn("12345678");
-        when(factory.getLinkClient(any(), any())).thenReturn(removeOfficersClient);
+        when(extractor.extractPatchLinkRequest(any())).thenReturn("12345678");
+        when(factory.getLinkClient(any(), any())).thenReturn(removeOfficersLinkClient);
 
         // when
         router.route(message, "deltaType");
 
         // then
-        verify(extractor).extractCompanyNumber("company/12345678/officers");
-        verify(removeOfficersClient).patchLink("12345678");
+        verify(extractor).extractPatchLinkRequest("company/12345678/officers");
+        verify(removeOfficersLinkClient).patchLink("12345678");
     }
 }

--- a/src/test/java/uk/gov/companieshouse/company/links/service/NullLinkClientTest.java
+++ b/src/test/java/uk/gov/companieshouse/company/links/service/NullLinkClientTest.java
@@ -1,0 +1,35 @@
+package uk.gov.companieshouse.company.links.service;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.function.Executable;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.companieshouse.company.links.exception.NonRetryableErrorException;
+import uk.gov.companieshouse.company.links.type.PatchLinkRequest;
+import uk.gov.companieshouse.logging.Logger;
+
+@ExtendWith(MockitoExtension.class)
+class NullLinkClientTest {
+
+    private static final String COMPANY_NUMBER = "12345678";
+
+    @Mock
+    private Logger logger;
+
+    @InjectMocks
+    private NullLinkClient client;
+
+    private final PatchLinkRequest linkRequest = new PatchLinkRequest(COMPANY_NUMBER);
+
+    @Test
+    void shouldThrowNonRetryableErrorExceptionWhenPatchLinkInvoked() {
+        Executable actual = () -> client.patchLink(linkRequest);
+
+        assertThrows(NonRetryableErrorException.class, actual);
+    }
+
+}

--- a/src/test/java/uk/gov/companieshouse/company/links/service/RemoveOfficersClientTest.java
+++ b/src/test/java/uk/gov/companieshouse/company/links/service/RemoveOfficersClientTest.java
@@ -1,155 +1,82 @@
 package uk.gov.companieshouse.company.links.service;
 
-import com.google.api.client.http.HttpHeaders;
-import com.google.api.client.http.HttpResponseException;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.function.Executable;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import uk.gov.companieshouse.api.InternalApiClient;
-import uk.gov.companieshouse.api.error.ApiErrorResponseException;
-import uk.gov.companieshouse.api.handler.company.PrivateCompanyLinksResourceHandler;
-import uk.gov.companieshouse.api.handler.company.links.request.PrivateCompanyOfficersLinksRemove;
-import uk.gov.companieshouse.api.handler.exception.URIValidationException;
-import uk.gov.companieshouse.api.model.ApiResponse;
-import uk.gov.companieshouse.company.links.exception.NonRetryableErrorException;
+import uk.gov.companieshouse.api.appointment.ItemLinkTypes;
+import uk.gov.companieshouse.api.appointment.LinkTypes;
+import uk.gov.companieshouse.api.appointment.OfficerList;
+import uk.gov.companieshouse.api.appointment.OfficerSummary;
 import uk.gov.companieshouse.company.links.exception.RetryableErrorException;
 import uk.gov.companieshouse.company.links.type.PatchLinkRequest;
 import uk.gov.companieshouse.logging.Logger;
 
-import java.util.Collections;
-import java.util.function.Supplier;
-
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
-
 @ExtendWith(MockitoExtension.class)
 class RemoveOfficersClientTest {
+
     private static final String COMPANY_NUMBER = "12345678";
-    private static final String PATH = String.format("/company/%s/links/officers/delete", COMPANY_NUMBER);
+    private static final String RESOURCE_ID = "abcdefg";
+
+    private final PatchLinkRequest linkRequest = new PatchLinkRequest(COMPANY_NUMBER, RESOURCE_ID);
 
     @Mock
-    private Supplier<InternalApiClient> internalApiClientSupplier;
+    private AppointmentsListClient appointmentsListClient;
 
     @Mock
-    private InternalApiClient internalApiClient;
-
-    @Mock
-    private PrivateCompanyLinksResourceHandler resourceHandler;
-
-    @Mock
-    private PrivateCompanyOfficersLinksRemove officersLinksRemoveHandler;
+    private RemoveOfficersLinkClient removeOfficersLinkClient;
 
     @Mock
     private Logger logger;
 
     @InjectMocks
-    private RemoveOfficersLinkClient client;
-
-    private final PatchLinkRequest linkRequest = new PatchLinkRequest(COMPANY_NUMBER);
+    private RemoveOfficersClient removeOfficersClient;
 
     @Test
-    void testUpsert() throws ApiErrorResponseException, URIValidationException {
-        // given
-        when(internalApiClientSupplier.get()).thenReturn(internalApiClient);
-        when(internalApiClient.privateCompanyLinksResourceHandler()).thenReturn(resourceHandler);
-        when(resourceHandler.removeOfficersCompanyLink(anyString())).thenReturn(officersLinksRemoveHandler);
-        when(officersLinksRemoveHandler.execute()).thenReturn(new ApiResponse<>(200, Collections.emptyMap()));
+    void shouldRemoveOfficersLinkWhenZeroAppointmentsFound() {
+        when(appointmentsListClient.getAppointmentsList(COMPANY_NUMBER)).thenReturn(
+                new OfficerList()
+                        .totalResults(0));
 
-        // when
-        client.patchLink(linkRequest);
+        removeOfficersClient.patchLink(linkRequest);
 
-        // then
-        verify(resourceHandler).removeOfficersCompanyLink(PATH);
-        verify(officersLinksRemoveHandler).execute();
+        verify(removeOfficersLinkClient).patchLink(linkRequest);
     }
 
     @Test
-    void testThrowNonRetryableExceptionIfClientErrorReturned() throws ApiErrorResponseException, URIValidationException {
-        // given
-        when(internalApiClientSupplier.get()).thenReturn(internalApiClient);
-        when(internalApiClient.privateCompanyLinksResourceHandler()).thenReturn(resourceHandler);
-        when(resourceHandler.removeOfficersCompanyLink(anyString())).thenReturn(officersLinksRemoveHandler);
-        when(officersLinksRemoveHandler.execute()).thenThrow(new ApiErrorResponseException(new HttpResponseException.Builder(404, "Not found", new HttpHeaders())));
+    void shouldThrowRetryableErrorExceptionWhenOfficerStillPresentInOfficerList() {
+        when(appointmentsListClient.getAppointmentsList(COMPANY_NUMBER)).thenReturn(
+                new OfficerList()
+                        .totalResults(1)
+                        .items(List.of(new OfficerSummary()
+                                .links(new ItemLinkTypes()
+                                        .self(String.format("/company/%s/%s",
+                                                COMPANY_NUMBER, RESOURCE_ID))))));
 
-        // when
-        client.patchLink(linkRequest);
+        Executable actual = () -> removeOfficersClient.patchLink(linkRequest);
 
-        // then
-        verify(resourceHandler).removeOfficersCompanyLink(PATH);
-        verify(officersLinksRemoveHandler).execute();
-        verify(logger).info("HTTP 404 Not Found returned; company profile does not exist");
-    }
-
-    @Test
-    void testThrowNonRetryableExceptionIf409Returned() throws ApiErrorResponseException, URIValidationException {
-        // given
-        when(internalApiClientSupplier.get()).thenReturn(internalApiClient);
-        when(internalApiClient.privateCompanyLinksResourceHandler()).thenReturn(resourceHandler);
-        when(resourceHandler.removeOfficersCompanyLink(anyString())).thenReturn(officersLinksRemoveHandler);
-        when(officersLinksRemoveHandler.execute()).thenThrow(new ApiErrorResponseException(new HttpResponseException.Builder(409, "Conflict", new HttpHeaders())));
-
-        // when
-        client.patchLink(linkRequest);
-
-        // then
-        verify(resourceHandler).removeOfficersCompanyLink(PATH);
-        verify(officersLinksRemoveHandler).execute();
-        verify(logger).info("HTTP 409 Conflict returned; company profile does not have an officers link already");
-    }
-
-    @Test
-    void testThrowRetryableExceptionIfServerErrorReturned() throws ApiErrorResponseException, URIValidationException {
-        // given
-        when(internalApiClientSupplier.get()).thenReturn(internalApiClient);
-        when(internalApiClient.privateCompanyLinksResourceHandler()).thenReturn(resourceHandler);
-        when(resourceHandler.removeOfficersCompanyLink(anyString())).thenReturn(officersLinksRemoveHandler);
-        when(officersLinksRemoveHandler.execute()).thenThrow(new ApiErrorResponseException(new HttpResponseException.Builder(500, "Internal server error", new HttpHeaders())));
-
-        // when
-        Executable actual = () -> client.patchLink(linkRequest);
-
-        // then
         assertThrows(RetryableErrorException.class, actual);
-        verify(resourceHandler).removeOfficersCompanyLink(PATH);
-        verify(officersLinksRemoveHandler).execute();
+        verifyNoInteractions(removeOfficersLinkClient);
     }
 
     @Test
-    void testThrowRetryableExceptionIfIllegalArgumentExceptionIsCaught() throws ApiErrorResponseException, URIValidationException {
-        // given
-        when(internalApiClientSupplier.get()).thenReturn(internalApiClient);
-        when(internalApiClient.privateCompanyLinksResourceHandler()).thenReturn(resourceHandler);
-        when(resourceHandler.removeOfficersCompanyLink(anyString())).thenReturn(officersLinksRemoveHandler);
-        when(officersLinksRemoveHandler.execute()).thenThrow(new IllegalArgumentException("Internal server error"));
+    void shouldNotRemoveOfficerLinkWhenOfficerListContainsOtherOfficers() {
+        when(appointmentsListClient.getAppointmentsList(COMPANY_NUMBER)).thenReturn(
+                new OfficerList()
+                        .totalResults(1)
+                        .links(new LinkTypes().self(String.format("/company/%s/%s",
+                                COMPANY_NUMBER, "some-other-id"))));
 
-        // when
-        Executable actual = () -> client.patchLink(linkRequest);
+        removeOfficersClient.patchLink(linkRequest);
 
-        // then
-        assertThrows(RetryableErrorException.class, actual);
-        verify(resourceHandler).removeOfficersCompanyLink(PATH);
-        verify(officersLinksRemoveHandler).execute();
-    }
-
-    @Test
-    void testThrowNonRetryableExceptionIfComapnyNumberInvalid() throws ApiErrorResponseException, URIValidationException {
-        // given
-        when(internalApiClientSupplier.get()).thenReturn(internalApiClient);
-        when(internalApiClient.privateCompanyLinksResourceHandler()).thenReturn(resourceHandler);
-        when(resourceHandler.removeOfficersCompanyLink(anyString())).thenReturn(officersLinksRemoveHandler);
-        when(officersLinksRemoveHandler.execute()).thenThrow(new URIValidationException("Invalid URI"));
-
-        // when
-        Executable actual = () -> client.patchLink(new PatchLinkRequest("OC401invalid/companyNumber"));
-
-        // then
-        assertThrows(NonRetryableErrorException.class, actual);
-        verify(resourceHandler).removeOfficersCompanyLink("/company/OC401invalid/companyNumber/links/officers/delete");
-        verify(officersLinksRemoveHandler).execute();
+        verifyNoInteractions(removeOfficersLinkClient);
     }
 }

--- a/src/test/java/uk/gov/companieshouse/company/links/service/RemoveOfficersClientTest.java
+++ b/src/test/java/uk/gov/companieshouse/company/links/service/RemoveOfficersClientTest.java
@@ -16,6 +16,7 @@ import uk.gov.companieshouse.api.handler.exception.URIValidationException;
 import uk.gov.companieshouse.api.model.ApiResponse;
 import uk.gov.companieshouse.company.links.exception.NonRetryableErrorException;
 import uk.gov.companieshouse.company.links.exception.RetryableErrorException;
+import uk.gov.companieshouse.company.links.type.PatchLinkRequest;
 import uk.gov.companieshouse.logging.Logger;
 
 import java.util.Collections;
@@ -49,6 +50,8 @@ class RemoveOfficersClientTest {
     @InjectMocks
     private RemoveOfficersLinkClient client;
 
+    private final PatchLinkRequest linkRequest = new PatchLinkRequest(COMPANY_NUMBER);
+
     @Test
     void testUpsert() throws ApiErrorResponseException, URIValidationException {
         // given
@@ -58,7 +61,7 @@ class RemoveOfficersClientTest {
         when(officersLinksRemoveHandler.execute()).thenReturn(new ApiResponse<>(200, Collections.emptyMap()));
 
         // when
-        client.patchLink(COMPANY_NUMBER);
+        client.patchLink(linkRequest);
 
         // then
         verify(resourceHandler).removeOfficersCompanyLink(PATH);
@@ -74,7 +77,7 @@ class RemoveOfficersClientTest {
         when(officersLinksRemoveHandler.execute()).thenThrow(new ApiErrorResponseException(new HttpResponseException.Builder(404, "Not found", new HttpHeaders())));
 
         // when
-        client.patchLink(COMPANY_NUMBER);
+        client.patchLink(linkRequest);
 
         // then
         verify(resourceHandler).removeOfficersCompanyLink(PATH);
@@ -91,7 +94,7 @@ class RemoveOfficersClientTest {
         when(officersLinksRemoveHandler.execute()).thenThrow(new ApiErrorResponseException(new HttpResponseException.Builder(409, "Conflict", new HttpHeaders())));
 
         // when
-        client.patchLink(COMPANY_NUMBER);
+        client.patchLink(linkRequest);
 
         // then
         verify(resourceHandler).removeOfficersCompanyLink(PATH);
@@ -108,7 +111,7 @@ class RemoveOfficersClientTest {
         when(officersLinksRemoveHandler.execute()).thenThrow(new ApiErrorResponseException(new HttpResponseException.Builder(500, "Internal server error", new HttpHeaders())));
 
         // when
-        Executable actual = () -> client.patchLink(COMPANY_NUMBER);
+        Executable actual = () -> client.patchLink(linkRequest);
 
         // then
         assertThrows(RetryableErrorException.class, actual);
@@ -125,7 +128,7 @@ class RemoveOfficersClientTest {
         when(officersLinksRemoveHandler.execute()).thenThrow(new IllegalArgumentException("Internal server error"));
 
         // when
-        Executable actual = () -> client.patchLink(COMPANY_NUMBER);
+        Executable actual = () -> client.patchLink(linkRequest);
 
         // then
         assertThrows(RetryableErrorException.class, actual);
@@ -142,7 +145,7 @@ class RemoveOfficersClientTest {
         when(officersLinksRemoveHandler.execute()).thenThrow(new URIValidationException("Invalid URI"));
 
         // when
-        Executable actual = () -> client.patchLink("OC401invalid/companyNumber");
+        Executable actual = () -> client.patchLink(new PatchLinkRequest("OC401invalid/companyNumber"));
 
         // then
         assertThrows(NonRetryableErrorException.class, actual);

--- a/src/test/java/uk/gov/companieshouse/company/links/service/RemoveOfficersClientTest.java
+++ b/src/test/java/uk/gov/companieshouse/company/links/service/RemoveOfficersClientTest.java
@@ -47,7 +47,7 @@ class RemoveOfficersClientTest {
     private Logger logger;
 
     @InjectMocks
-    private RemoveOfficersClient client;
+    private RemoveOfficersLinkClient client;
 
     @Test
     void testUpsert() throws ApiErrorResponseException, URIValidationException {

--- a/src/test/java/uk/gov/companieshouse/company/links/service/RemoveOfficersLinkClientTest.java
+++ b/src/test/java/uk/gov/companieshouse/company/links/service/RemoveOfficersLinkClientTest.java
@@ -2,6 +2,7 @@ package uk.gov.companieshouse.company.links.service;
 
 import com.google.api.client.http.HttpHeaders;
 import com.google.api.client.http.HttpResponseException;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.function.Executable;
@@ -52,12 +53,16 @@ class RemoveOfficersLinkClientTest {
 
     private final PatchLinkRequest linkRequest = new PatchLinkRequest(COMPANY_NUMBER);
 
-    @Test
-    void testUpsert() throws ApiErrorResponseException, URIValidationException {
-        // given
+    @BeforeEach
+    void setup() {
         when(internalApiClientSupplier.get()).thenReturn(internalApiClient);
         when(internalApiClient.privateCompanyLinksResourceHandler()).thenReturn(resourceHandler);
         when(resourceHandler.removeOfficersCompanyLink(anyString())).thenReturn(officersLinksRemoveHandler);
+    }
+
+    @Test
+    void testUpsert() throws ApiErrorResponseException, URIValidationException {
+        // given
         when(officersLinksRemoveHandler.execute()).thenReturn(new ApiResponse<>(200, Collections.emptyMap()));
 
         // when
@@ -71,9 +76,6 @@ class RemoveOfficersLinkClientTest {
     @Test
     void testThrowNonRetryableExceptionIfClientErrorReturned() throws ApiErrorResponseException, URIValidationException {
         // given
-        when(internalApiClientSupplier.get()).thenReturn(internalApiClient);
-        when(internalApiClient.privateCompanyLinksResourceHandler()).thenReturn(resourceHandler);
-        when(resourceHandler.removeOfficersCompanyLink(anyString())).thenReturn(officersLinksRemoveHandler);
         when(officersLinksRemoveHandler.execute()).thenThrow(new ApiErrorResponseException(new HttpResponseException.Builder(404, "Not found", new HttpHeaders())));
 
         // when
@@ -88,9 +90,6 @@ class RemoveOfficersLinkClientTest {
     @Test
     void testThrowNonRetryableExceptionIf409Returned() throws ApiErrorResponseException, URIValidationException {
         // given
-        when(internalApiClientSupplier.get()).thenReturn(internalApiClient);
-        when(internalApiClient.privateCompanyLinksResourceHandler()).thenReturn(resourceHandler);
-        when(resourceHandler.removeOfficersCompanyLink(anyString())).thenReturn(officersLinksRemoveHandler);
         when(officersLinksRemoveHandler.execute()).thenThrow(new ApiErrorResponseException(new HttpResponseException.Builder(409, "Conflict", new HttpHeaders())));
 
         // when
@@ -105,9 +104,6 @@ class RemoveOfficersLinkClientTest {
     @Test
     void testThrowRetryableExceptionIfServerErrorReturned() throws ApiErrorResponseException, URIValidationException {
         // given
-        when(internalApiClientSupplier.get()).thenReturn(internalApiClient);
-        when(internalApiClient.privateCompanyLinksResourceHandler()).thenReturn(resourceHandler);
-        when(resourceHandler.removeOfficersCompanyLink(anyString())).thenReturn(officersLinksRemoveHandler);
         when(officersLinksRemoveHandler.execute()).thenThrow(new ApiErrorResponseException(new HttpResponseException.Builder(500, "Internal server error", new HttpHeaders())));
 
         // when
@@ -122,9 +118,6 @@ class RemoveOfficersLinkClientTest {
     @Test
     void testThrowRetryableExceptionIfIllegalArgumentExceptionIsCaught() throws ApiErrorResponseException, URIValidationException {
         // given
-        when(internalApiClientSupplier.get()).thenReturn(internalApiClient);
-        when(internalApiClient.privateCompanyLinksResourceHandler()).thenReturn(resourceHandler);
-        when(resourceHandler.removeOfficersCompanyLink(anyString())).thenReturn(officersLinksRemoveHandler);
         when(officersLinksRemoveHandler.execute()).thenThrow(new IllegalArgumentException("Internal server error"));
 
         // when
@@ -139,9 +132,6 @@ class RemoveOfficersLinkClientTest {
     @Test
     void testThrowNonRetryableExceptionIfComapnyNumberInvalid() throws ApiErrorResponseException, URIValidationException {
         // given
-        when(internalApiClientSupplier.get()).thenReturn(internalApiClient);
-        when(internalApiClient.privateCompanyLinksResourceHandler()).thenReturn(resourceHandler);
-        when(resourceHandler.removeOfficersCompanyLink(anyString())).thenReturn(officersLinksRemoveHandler);
         when(officersLinksRemoveHandler.execute()).thenThrow(new URIValidationException("Invalid URI"));
 
         // when

--- a/src/test/java/uk/gov/companieshouse/company/links/service/RemoveOfficersLinkClientTest.java
+++ b/src/test/java/uk/gov/companieshouse/company/links/service/RemoveOfficersLinkClientTest.java
@@ -1,0 +1,155 @@
+package uk.gov.companieshouse.company.links.service;
+
+import com.google.api.client.http.HttpHeaders;
+import com.google.api.client.http.HttpResponseException;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.function.Executable;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.companieshouse.api.InternalApiClient;
+import uk.gov.companieshouse.api.error.ApiErrorResponseException;
+import uk.gov.companieshouse.api.handler.company.PrivateCompanyLinksResourceHandler;
+import uk.gov.companieshouse.api.handler.company.links.request.PrivateCompanyOfficersLinksRemove;
+import uk.gov.companieshouse.api.handler.exception.URIValidationException;
+import uk.gov.companieshouse.api.model.ApiResponse;
+import uk.gov.companieshouse.company.links.exception.NonRetryableErrorException;
+import uk.gov.companieshouse.company.links.exception.RetryableErrorException;
+import uk.gov.companieshouse.company.links.type.PatchLinkRequest;
+import uk.gov.companieshouse.logging.Logger;
+
+import java.util.Collections;
+import java.util.function.Supplier;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class RemoveOfficersLinkClientTest {
+    private static final String COMPANY_NUMBER = "12345678";
+    private static final String PATH = String.format("/company/%s/links/officers/delete", COMPANY_NUMBER);
+
+    @Mock
+    private Supplier<InternalApiClient> internalApiClientSupplier;
+
+    @Mock
+    private InternalApiClient internalApiClient;
+
+    @Mock
+    private PrivateCompanyLinksResourceHandler resourceHandler;
+
+    @Mock
+    private PrivateCompanyOfficersLinksRemove officersLinksRemoveHandler;
+
+    @Mock
+    private Logger logger;
+
+    @InjectMocks
+    private RemoveOfficersLinkClient client;
+
+    private final PatchLinkRequest linkRequest = new PatchLinkRequest(COMPANY_NUMBER);
+
+    @Test
+    void testUpsert() throws ApiErrorResponseException, URIValidationException {
+        // given
+        when(internalApiClientSupplier.get()).thenReturn(internalApiClient);
+        when(internalApiClient.privateCompanyLinksResourceHandler()).thenReturn(resourceHandler);
+        when(resourceHandler.removeOfficersCompanyLink(anyString())).thenReturn(officersLinksRemoveHandler);
+        when(officersLinksRemoveHandler.execute()).thenReturn(new ApiResponse<>(200, Collections.emptyMap()));
+
+        // when
+        client.patchLink(linkRequest);
+
+        // then
+        verify(resourceHandler).removeOfficersCompanyLink(PATH);
+        verify(officersLinksRemoveHandler).execute();
+    }
+
+    @Test
+    void testThrowNonRetryableExceptionIfClientErrorReturned() throws ApiErrorResponseException, URIValidationException {
+        // given
+        when(internalApiClientSupplier.get()).thenReturn(internalApiClient);
+        when(internalApiClient.privateCompanyLinksResourceHandler()).thenReturn(resourceHandler);
+        when(resourceHandler.removeOfficersCompanyLink(anyString())).thenReturn(officersLinksRemoveHandler);
+        when(officersLinksRemoveHandler.execute()).thenThrow(new ApiErrorResponseException(new HttpResponseException.Builder(404, "Not found", new HttpHeaders())));
+
+        // when
+        client.patchLink(linkRequest);
+
+        // then
+        verify(resourceHandler).removeOfficersCompanyLink(PATH);
+        verify(officersLinksRemoveHandler).execute();
+        verify(logger).info("HTTP 404 Not Found returned; company profile does not exist");
+    }
+
+    @Test
+    void testThrowNonRetryableExceptionIf409Returned() throws ApiErrorResponseException, URIValidationException {
+        // given
+        when(internalApiClientSupplier.get()).thenReturn(internalApiClient);
+        when(internalApiClient.privateCompanyLinksResourceHandler()).thenReturn(resourceHandler);
+        when(resourceHandler.removeOfficersCompanyLink(anyString())).thenReturn(officersLinksRemoveHandler);
+        when(officersLinksRemoveHandler.execute()).thenThrow(new ApiErrorResponseException(new HttpResponseException.Builder(409, "Conflict", new HttpHeaders())));
+
+        // when
+        client.patchLink(linkRequest);
+
+        // then
+        verify(resourceHandler).removeOfficersCompanyLink(PATH);
+        verify(officersLinksRemoveHandler).execute();
+        verify(logger).info("HTTP 409 Conflict returned; company profile does not have an officers link already");
+    }
+
+    @Test
+    void testThrowRetryableExceptionIfServerErrorReturned() throws ApiErrorResponseException, URIValidationException {
+        // given
+        when(internalApiClientSupplier.get()).thenReturn(internalApiClient);
+        when(internalApiClient.privateCompanyLinksResourceHandler()).thenReturn(resourceHandler);
+        when(resourceHandler.removeOfficersCompanyLink(anyString())).thenReturn(officersLinksRemoveHandler);
+        when(officersLinksRemoveHandler.execute()).thenThrow(new ApiErrorResponseException(new HttpResponseException.Builder(500, "Internal server error", new HttpHeaders())));
+
+        // when
+        Executable actual = () -> client.patchLink(linkRequest);
+
+        // then
+        assertThrows(RetryableErrorException.class, actual);
+        verify(resourceHandler).removeOfficersCompanyLink(PATH);
+        verify(officersLinksRemoveHandler).execute();
+    }
+
+    @Test
+    void testThrowRetryableExceptionIfIllegalArgumentExceptionIsCaught() throws ApiErrorResponseException, URIValidationException {
+        // given
+        when(internalApiClientSupplier.get()).thenReturn(internalApiClient);
+        when(internalApiClient.privateCompanyLinksResourceHandler()).thenReturn(resourceHandler);
+        when(resourceHandler.removeOfficersCompanyLink(anyString())).thenReturn(officersLinksRemoveHandler);
+        when(officersLinksRemoveHandler.execute()).thenThrow(new IllegalArgumentException("Internal server error"));
+
+        // when
+        Executable actual = () -> client.patchLink(linkRequest);
+
+        // then
+        assertThrows(RetryableErrorException.class, actual);
+        verify(resourceHandler).removeOfficersCompanyLink(PATH);
+        verify(officersLinksRemoveHandler).execute();
+    }
+
+    @Test
+    void testThrowNonRetryableExceptionIfComapnyNumberInvalid() throws ApiErrorResponseException, URIValidationException {
+        // given
+        when(internalApiClientSupplier.get()).thenReturn(internalApiClient);
+        when(internalApiClient.privateCompanyLinksResourceHandler()).thenReturn(resourceHandler);
+        when(resourceHandler.removeOfficersCompanyLink(anyString())).thenReturn(officersLinksRemoveHandler);
+        when(officersLinksRemoveHandler.execute()).thenThrow(new URIValidationException("Invalid URI"));
+
+        // when
+        Executable actual = () -> client.patchLink(new PatchLinkRequest("OC401invalid/companyNumber"));
+
+        // then
+        assertThrows(NonRetryableErrorException.class, actual);
+        verify(resourceHandler).removeOfficersCompanyLink("/company/OC401invalid/companyNumber/links/officers/delete");
+        verify(officersLinksRemoveHandler).execute();
+    }
+}


### PR DESCRIPTION
* Added a check that company appointments list is empty before removing the officers link
* Refactored the LinkRouter to call its associated client with a PatchLinkRequest rather than a company number
* Refactored LinkRouter clients to take a PatchLinkRequest
* Updated Spring version in the POM to latest 2.7.x available

[DSND-1580](https://companieshouse.atlassian.net/browse/DSND-1580)

[DSND-1580]: https://companieshouse.atlassian.net/browse/DSND-1580?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ