### PR TITLE
DSND-2375: Remove NonRetryableException from 409 conflict.

### DIFF
--- a/src/main/java/uk/gov/companieshouse/company/links/util/ResponseHandler.java
+++ b/src/main/java/uk/gov/companieshouse/company/links/util/ResponseHandler.java
@@ -68,8 +68,6 @@ public class ResponseHandler {
         } else if (HttpStatus.valueOf(ex.getStatusCode()).equals(HttpStatus.CONFLICT)) {
             logger.info(String.format(CONFLICT_ERROR_MSG, "409 Conflict", linkType),
                     DataMapHolder.getLogMap());
-            throw new NonRetryableErrorException(String.format(CONFLICT_ERROR_MSG,
-                    "409 Conflict", linkType), ex);
         } else if (HttpStatus.valueOf(ex.getStatusCode()).equals(HttpStatus.NOT_FOUND)) {
             logger.info(String.format(NOT_FOUND_ERROR_MSG, "404 Not Found"));
             throw new RetryableErrorException(String.format(NOT_FOUND_ERROR_MSG,

--- a/src/test/java/uk/gov/companieshouse/company/links/util/ResponseHandlerTest.java
+++ b/src/test/java/uk/gov/companieshouse/company/links/util/ResponseHandlerTest.java
@@ -1,7 +1,11 @@
 package uk.gov.companieshouse.company.links.util;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
 
 import com.google.api.client.http.HttpHeaders;
 import com.google.api.client.http.HttpResponseException;
@@ -90,9 +94,9 @@ class ResponseHandlerTest {
         Executable executable = () -> responseHandler.handle(409, "PSC statements", apiErrorResponseException);
 
         // then
-        NonRetryableErrorException exception = assertThrows(NonRetryableErrorException.class, executable);
-        assertEquals("HTTP 409 Conflict returned; "
-                + "company profile already has a PSC statements link", exception.getMessage());
+        assertDoesNotThrow(executable);
+        verify(logger).info(eq("HTTP 409 Conflict returned; "
+                + "company profile already has a PSC statements link"), any());
     }
 
     @Test


### PR DESCRIPTION
Tested locally, does not publish conflict messages to the invalid topic anymore. 

[DSND-2375](https://companieshouse.atlassian.net/browse/DSND-2375)

[DSND-2375]: https://companieshouse.atlassian.net/browse/DSND-2375?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ