### PR TITLE
ASM-601: Fix CVEs and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,14 +34,10 @@ test-unit            Run unit & integration tests (see 'Makefile Changes' sectio
 
 ### Quick start
 
-1. Start Kafka and Zookeeper:
+1. Start Kafka:
    ```bash
    docker-compose up -d
    ```
-   > **Note:** If you see a conflict error for the `kafka-manager` container, remove the old one first:
-   > ```bash
-   > docker stop kafka-manager && docker rm kafka-manager
-   > ```
 
 2. Build the project:
    ```bash
@@ -72,20 +68,20 @@ docker-compose exec kafka bash
 
 Then inside the container:
 ```bash
-kafka-topics.sh --create --zookeeper zookeeper:2181 --replication-factor 1 --partitions 1 --topic stream-filing-history
-kafka-topics.sh --create --zookeeper zookeeper:2181 --replication-factor 1 --partitions 1 --topic stream-company-insolvency
-kafka-topics.sh --create --zookeeper zookeeper:2181 --replication-factor 1 --partitions 1 --topic stream-company-charges
-kafka-topics.sh --create --zookeeper zookeeper:2181 --replication-factor 1 --partitions 1 --topic stream-company-psc
-kafka-topics.sh --create --zookeeper zookeeper:2181 --replication-factor 1 --partitions 1 --topic stream-company-officers
-kafka-topics.sh --create --zookeeper zookeeper:2181 --replication-factor 1 --partitions 1 --topic stream-company-exemptions
-kafka-topics.sh --create --zookeeper zookeeper:2181 --replication-factor 1 --partitions 1 --topic stream-company-profile
-kafka-topics.sh --create --zookeeper zookeeper:2181 --replication-factor 1 --partitions 1 --topic stream-psc-statements
-kafka-topics.sh --create --zookeeper zookeeper:2181 --replication-factor 1 --partitions 1 --topic stream-registers
+kafka-topics.sh --create --bootstrap-server localhost:9092 --replication-factor 1 --partitions 1 --topic stream-filing-history
+kafka-topics.sh --create --bootstrap-server localhost:9092 --replication-factor 1 --partitions 1 --topic stream-company-insolvency
+kafka-topics.sh --create --bootstrap-server localhost:9092 --replication-factor 1 --partitions 1 --topic stream-company-charges
+kafka-topics.sh --create --bootstrap-server localhost:9092 --replication-factor 1 --partitions 1 --topic stream-company-psc
+kafka-topics.sh --create --bootstrap-server localhost:9092 --replication-factor 1 --partitions 1 --topic stream-company-officers
+kafka-topics.sh --create --bootstrap-server localhost:9092 --replication-factor 1 --partitions 1 --topic stream-company-exemptions
+kafka-topics.sh --create --bootstrap-server localhost:9092 --replication-factor 1 --partitions 1 --topic stream-company-profile
+kafka-topics.sh --create --bootstrap-server localhost:9092 --replication-factor 1 --partitions 1 --topic stream-psc-statements
+kafka-topics.sh --create --bootstrap-server localhost:9092 --replication-factor 1 --partitions 1 --topic stream-registers
 ```
 
 ### List kafka topics
 ```bash
-kafka-topics.sh --list --zookeeper zookeeper:2181
+kafka-topics.sh --list --bootstrap-server localhost:9092
 ```
 
 ### Produce kafka test messages locally

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,36 +1,18 @@
-version: '3.1'
-
 services:
-
-  zookeeper:
-    image: confluentinc/cp-zookeeper:latest
-    environment:
-      ZOOKEEPER_CLIENT_PORT: 2181
-      ZOOKEEPER_TICK_TIME: 2000
 
   kafka:
     image: confluentinc/cp-kafka:latest
-    depends_on:
-      - zookeeper
     ports:
       - 29092:29092
     environment:
-      KAFKA_BROKER_ID: 1
-      KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
+      KAFKA_NODE_ID: 1
+      KAFKA_PROCESS_ROLES: broker,controller
+      KAFKA_LISTENERS: PLAINTEXT://kafka:9092,PLAINTEXT_HOST://0.0.0.0:29092,CONTROLLER://kafka:9093
       KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka:9092,PLAINTEXT_HOST://localhost:29092
-      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: PLAINTEXT:PLAINTEXT,PLAINTEXT_HOST:PLAINTEXT
-      KAFKA_INTER_BROKER_LISTENER_NAME: PLAINTEXT
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: PLAINTEXT:PLAINTEXT,PLAINTEXT_HOST:PLAINTEXT,CONTROLLER:PLAINTEXT
+      KAFKA_CONTROLLER_LISTENER_NAMES: CONTROLLER
+      KAFKA_CONTROLLER_QUORUM_VOTERS: 1@kafka:9093
       KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
-
-  kafka_manager:
-    image: hlebalbau/kafka-manager:stable
-    container_name: kafka-manager
-    restart: always
-    depends_on:
-      - zookeeper
-    ports:
-      - "9000:9000"
-    environment:
-      ZK_HOSTS: "zookeeper:2181"
-      APPLICATION_SECRET: "random-secret"
-      command: -Dpidfile.path = /dev/null
+      KAFKA_INTER_BROKER_LISTENER_NAME: PLAINTEXT
+      KAFKA_LOG_DIRS: /var/lib/kafka/data
+      CLUSTER_ID: MkU3OEVBNTcwNTJENDM2Qk

--- a/pom.xml
+++ b/pom.xml
@@ -37,6 +37,10 @@
     <private-api-sdk-java.version>4.0.473</private-api-sdk-java.version>
     <api-sdk-manager-java-library.version>3.0.15</api-sdk-manager-java-library.version>
 
+    <!--Dependency overrides-->
+    <log4j2.version>2.25.3</log4j2.version>
+    <jetty.version>12.0.32</jetty.version>
+
     <!--Testing Dependencies-->
     <wiremock.standalone.version>3.13.1</wiremock.standalone.version>
     <cucumber.version>7.31.0</cucumber.version>
@@ -64,12 +68,33 @@
 
   <dependencyManagement>
     <dependencies>
+      <!-- Jetty BOMs before Spring Boot to fix CVE-2025-11143 and CVE-2026-1605 -->
+      <dependency>
+        <groupId>org.eclipse.jetty</groupId>
+        <artifactId>jetty-bom</artifactId>
+        <version>${jetty.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.eclipse.jetty.ee10</groupId>
+        <artifactId>jetty-ee10-bom</artifactId>
+        <version>${jetty.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
       <dependency>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-dependencies</artifactId>
         <version>${spring.boot.version}</version>
         <type>pom</type>
         <scope>import</scope>
+      </dependency>
+      <!-- Explicit override to fix CVE-2025-68161; transitive CH deps declare a hardcoded version -->
+      <dependency>
+        <groupId>org.apache.logging.log4j</groupId>
+        <artifactId>log4j-api</artifactId>
+        <version>${log4j2.version}</version>
       </dependency>
     </dependencies>
   </dependencyManagement>


### PR DESCRIPTION
  Jira Ticket                                                                                                                                        
  https://companieshouse.atlassian.net/browse/ASM-601                                                                                                
                                                                      
  Summary                                                                                                                                            
                                                                                                                                                     
  Fixes CI pipeline failures and resolves three dependency-check CVEs:                                                                               
                                                                                                                                                     
  - Migrates docker-compose.yml from ZooKeeper mode to KRaft mode. confluentinc/cp-kafka:latest now pulls Confluent Platform 8.x, which removed ZooKeeper entirely, causing Kafka to fail to start in CI. The ZooKeeper and Kafka Manager services have also been removed from the compose file.
  
  - Upgrades log4j2 to 2.25.3 to fix CVE-2025-68161 (Socket Appender TLS hostname verification bypass). An explicit dependencyManagement entry is added for log4j-api because a transitive CH dependency declares it with a hardcoded version, bypassing the log4j2.version property.
                  
  - Imports org.eclipse.jetty:jetty-bom and org.eclipse.jetty.ee10:jetty-ee10-bom at 12.0.32 before the Spring Boot BOM to fix CVE-2025-11143 (URI parsing differential, CVSS 6.5) and CVE-2026-1605 (GzipHandler native memory leak, CVSS 7.5) across all Jetty artifact groups. 